### PR TITLE
Parse *most* SOURCE entries

### DIFF
--- a/lib/iev/termbase/term_builder.rb
+++ b/lib/iev/termbase/term_builder.rb
@@ -393,7 +393,7 @@ module Iev
           # "SI Brochure, 9th edition, 2019, 2.3.1, modified – The definition from the SI Brochure has been adapted to comply with the IEV rules. Notes 1 to 4 to entry have been added."
           # SI Brochure, 9th edition, 2019, Appendix 1, modified – The definition in the SI Brochure has been revised to comply with the IEV rules. The synonym "Loschmidt number" and the symbol "<i>L</i>" have been added to Note 2 to entry.
           # Brochure sur le SI, 9<sup>e</sup> édition, 2019, Annexe 1, modifié – La définition d e la Brochure sur le SI a été révisée à des fins de mise en conformité avec les règles de l’IEV. Le synonyme "nombre de Loschmidt" et le symbole "<i>L</i>" ont été ajoutés dans la Note 2 à l’article.
-          "BIPM SI Brochure"
+          "BBIPM SI Brochure TEMP DISABLED DUE TO RELATON"
 
         when /VIM/
           "JCGM VIM"
@@ -654,7 +654,7 @@ module Iev
 
         pp h
 
-        item = ::Iev::Termbase::RelatonDb.instance.fetch(clean_ref)
+        item = ::Iev::Termbase::RelatonDb.instance.fetch(source_ref)
 
         src = {}
 

--- a/lib/iev/termbase/term_builder.rb
+++ b/lib/iev/termbase/term_builder.rb
@@ -1,3 +1,5 @@
+require 'pp'
+
 require "iev/termbase/relaton_db"
 require "iev/termbase/iso_639_code"
 require "iev/termbase/nested_term_builder"
@@ -381,73 +383,333 @@ module Iev
         end
       end
 
-      def extract_authoritative_source
-        source = find_value_for("SOURCE")
+      def extract_source_ref(str)
 
-        return nil if source.nil?
+        # ISO/IEC 2382:2015 (https://www.iso.org/obp/ui/#iso:std:iso-iec:2382:ed-1:v1:en), 2126371, modified – Notes 1 to 3 to entry have been omitted.
 
-        # source = "ISO/IEC GUIDE 99:2007 1.26"
-        raw_ref = source.match(/\A[^,\()]+/).to_s
 
-        relation_type = case raw_ref
+        case str
+        when /SI Brochure/, /Brochure sur le SI/
+          # "SI Brochure, 9th edition, 2019, 2.3.1, modified – The definition from the SI Brochure has been adapted to comply with the IEV rules. Notes 1 to 4 to entry have been added."
+          # SI Brochure, 9th edition, 2019, Appendix 1, modified – The definition in the SI Brochure has been revised to comply with the IEV rules. The synonym "Loschmidt number" and the symbol "<i>L</i>" have been added to Note 2 to entry.
+          # Brochure sur le SI, 9<sup>e</sup> édition, 2019, Annexe 1, modifié – La définition d e la Brochure sur le SI a été révisée à des fins de mise en conformité avec les règles de l’IEV. Le synonyme "nombre de Loschmidt" et le symbole "<i>L</i>" ont été ajoutés dans la Note 2 à l’article.
+          "BIPM SI Brochure"
+
+        when /VIM/
+          "JCGM VIM"
+        # IEC 60050-121, 151-12-05
+        when /IEC 60050-(\d+), (\d{2,3}-\d{2,3}-\d{2,3})/
+          "IEC 60050-#{$LAST_MATCH_INFO[1]}"
+        when /IEC 60050-(\d+):(\d+), (\d{2,3}-\d{2,3}-\d{2,3})/
+          "IEC 60050-#{$LAST_MATCH_INFO[1]}:#{$LAST_MATCH_INFO[2]}"
+        when /(AIEA|IAEA) (\d+)/
+          "IAEA #{$LAST_MATCH_INFO[2]}"
+        when /IEC\sIEEE ([\d\:\-]+)/
+          "IEC/IEEE #{$LAST_MATCH_INFO[1]}".sub(/:\Z/, "")
+        when /CISPR ([\d\:\-]+)/
+          "IEC CISPR #{$LAST_MATCH_INFO[1]}"
+        when /RR (\d+)/
+          "ITU RR"
+        # IEC 50(845)
+        when /IEC (\d+)\((\d+)\)/
+          "IEC 600#{$LAST_MATCH_INFO[1]}-#{$LAST_MATCH_INFO[1]}"
+        when /(ISO|IEC)[\/\ ](PAS|TR|TS) ([\d\:\-]+)/
+          "#{$LAST_MATCH_INFO[1]}/#{$LAST_MATCH_INFO[2]} #{$LAST_MATCH_INFO[3]}".sub(/:\Z/, "")
+        when /ISO\/IEC ([\d\:\-]+)/
+          "ISO/IEC #{$LAST_MATCH_INFO[1]}".sub(/:\Z/, "")
+        when /ISO\/IEC\/IEEE ([\d\:\-]+)/
+          "ISO/IEC/IEEE #{$LAST_MATCH_INFO[1]}".sub(/:\Z/, "")
+
+        # ISO 140/4
+        when /ISO (\d+)\/(\d+)/
+          "ISO #{$LAST_MATCH_INFO[1]}-#{$LAST_MATCH_INFO[2]}"
+        when /Norme ISO (\d+)-(\d+)/
+          "ISO #{$LAST_MATCH_INFO[1]}:#{$LAST_MATCH_INFO[2]}"
+        when /ISO\/IEC Guide ([\d\:\-]+)/i
+          "ISO/IEC Guide #{$LAST_MATCH_INFO[1]}".sub(/:\Z/, "")
+        when /(ISO|IEC) Guide ([\d\:\-]+)/i
+          "#{$LAST_MATCH_INFO[1]} Guide #{$LAST_MATCH_INFO[2]}".sub(/:\Z/, "")
+
+        # ITU-T Recommendation F.791 (11/2015)
+        when /ITU-T Recommendation (\w.\d+) \((\d+\/\d+)\)/i
+          "ITU-T Recommendation #{$LAST_MATCH_INFO[1]} (#{$LAST_MATCH_INFO[2]})"
+
+        # ITU-T Recommendation F.791:2015
+        when /ITU-T Recommendation (\w.\d+):(\d+)/i
+          "ITU-T Recommendation #{$LAST_MATCH_INFO[1]} (#{$LAST_MATCH_INFO[2]})"
+
+        when /ITU-T Recommendation (\w\.\d+)/i
+          "ITU-T Recommendation #{$LAST_MATCH_INFO[1]}"
+
+        # ITU-R Recommendation 592 MOD
+        when /ITU-R Recommendation (\d+)/i
+          "ITU-R Recommendation #{$LAST_MATCH_INFO[1]}"
+        # ISO 669: 2000 3.1.16
+        when /ISO ([\d\-]+:\s?\d{4})/
+          "ISO #{$LAST_MATCH_INFO[1]}".sub(/:\Z/, "")
+        when /ISO ([\d\:\-]+)/
+          "ISO #{$LAST_MATCH_INFO[1]}".sub(/:\Z/, "")
+        when /IEC ([\d\:\-]+)/
+          "IEC #{$LAST_MATCH_INFO[1]}".sub(/:\Z/, "")
+        when /definition (\d\.[\d\.]+) of ([\d\-])/
+          "IEC #{$LAST_MATCH_INFO[2]}".sub(/:\Z/, "")
+        when /définition (\d\.[\d\.]+) de la ([\d\-])/
+          "IEC #{$LAST_MATCH_INFO[2]}".sub(/:\Z/, "")
+
+        when /IEV (\d{2,3}-\d{2,3}-\d{2,3})/, /(\d{2,3}-\d{2,3}-\d{2,3})/
+          "IEV"
+        when /IEV part\s+(\d+)/, /partie\s+(\d+)\s+de l'IEV/
+          "IEC 60050-#{$LAST_MATCH_INFO[1]}"
+
+        when /International Telecommunication Union (ITU) Constitution/,
+          /Constitution de l’Union internationale des télécommunications (UIT)/
+          "International Telecommunication Union (ITU) Constitution (Ed. 2015)"
+        else
+          puts "[FAILED TO PARSE SOURCE] #{str}"
+          str
+        end
+
+      end
+
+      def extract_source_clause(str)
+
+        # Strip out the modifications
+        str = str.sub(/[,\ ]*modif.+\s[-–].*\Z/, "")
+
+        # Strip these:
+        # see figure 466-6
+        # voir fig. 4.9
+        str = str.gsub(/\A(see|voir) fig. [\d\.]+/, "")
+        str = str.gsub(/\A(see|voir) figure [\d\.]+/, "")
+
+        # str = 'ITU-T Recommendation F.791:2015, 3.14,'
+        results = [
+          [/RR (\d+)/, "1"],
+          [/VIM (.+)/, "1"],
+          [/item (\d\.[\d\.]+)/, "1"],
+          [/d[eé]finition (\d[\d\.]+)/, "1"],
+          [/figure ([\d\.\-]+)/, "figure 1"],
+          [/fig\. ([\d\.\-]+)/, "figure 1"],
+          [/IEV (\d{2,3}-\d{2,3}-\d{2,3})/, "1"],
+          [/(\d{2,3}-\d{2,3}-\d{2,3})/, "1"],
+
+          # 221 04 03
+          [/(\d{3}\ \d{2}\ \d{2})/, "1"],
+          # ", 1.1"
+          # "SI Brochure, 9th edition, 2019, 2.3.1,"
+          [/,\s?(\d+\.[\d\.]+)/, "1"],
+
+          #  CLAUSENIL!!! SI Brochure, 9th edition, 2019, Appendix 1, modified
+          [/\d{4}, (Appendix \d)/, "1"],
+
+          #  CLAUSENIL!!! Brochure sur le SI, 9<sup>e</sup> édition, 2019, Annexe 1,
+          [/\d{4}, (Annexe \d)/, "1"],
+
+          #  International Telecommunication Union (ITU) Constitution (Ed. 2015), No. 1012 of the Annex,
+          # Constitution de l’Union internationale des télécommunications (UIT) (Ed. 2015), N° 1012 de l’Annexe,
+          [/, (No. \d{4} of the Annex)/, "1"],
+          [/, (N° \d{4} 1012 de l’Annexe)/, "1"],
+
+          # ISO/IEC 2382:2015 (https://www.iso.org/obp/ui/#iso:std:iso-iec:2382:ed-1:v1:en), 2126371,
+          [/\), (\d{7}),/, "1"],
+
+          # " 1.1 "
+          [/\s(\d+\.[\d\.]+)\s?/, "1"],
+          # "ISO/IEC Guide 2 (14.1)"
+          [/\((\d+\.[\d\.]+)\)/, "1"],
+
+          # "ISO/IEC Guide 2 (14.5 MOD)"
+          [/\((\d+\.[\d\.]+)\ MOD\)/, "1"],
+
+          # ISO 80000-10:2009, item 10-2.b,
+          # ISO 80000-10:2009, point 10-2.b,
+
+          [/\AISO 80000-10:2009, (item [\d\.\-]+\w?)/, "1"],
+          [/\AISO 80000-10:2009, (point [\d\.\-]+\w?)/, "1"],
+
+          # IEC 80000-13:2008, 13-9,
+          [/\AIEC 80000-13:2008, ([\d\.\-]+\w?),/, "1"],
+          [/\AIEC 80000-13:2008, ([\d\.\-]+\w?)\Z/, "1"],
+
+          # ISO 921:1997, definition 6,
+          # ISO 921:1997, définition 6,
+          [/\AISO [\d:]+, (d[ée]finition \d+)/, "1"],
+
+          # "ISO/IEC/IEEE 24765:2010,  <i>Systems and software engineering – Vocabulary</i>, 3.234 (2)
+          [/, ([\d\.\w]+ \(\d+\))/, "1"]
+        ].map do |regex, rule|
+          res = []
+          # puts "str is '#{str}'"
+          # puts "regex is '#{regex.to_s}'"
+          str.scan(regex).each do |result|
+            # puts "result is #{result.first}"
+            res << {
+              index: $~.offset(0)[0],
+              clause: result.first.strip
+            }
+          end
+          res
+          # sort by index and also the length of match
+        end.flatten.sort_by { |hash| [hash[:index], -hash[:clause].length] }
+
+        pp results
+
+        if results.first
+          results.first[:clause]
+        else
+          nil
+        end
+      end
+
+      def extract_source_relationship(str)
+        type = case str
+        when /≠/
+          :not_equal
+        when /≈/
+          :similar
         when /^([Ss]ee)|([Vv]oir)/
           :related
-        when raw_ref.include?("MOD")
+        when /MOD/, /ИЗМ/
+          :modified
+        when /modified/, /modifié/
           :modified
         when /^(from|d'après)/,
-          /^(definition\s+of)|(définition\s+de\s+la)/
+          /^(definition (.+) of)|(définition (.+) de la)/
           :identical
         else
           :identical
         end
 
-        clean_ref = clean_ref_string(raw_ref)
+        case str
+        when /^MOD ([\d\-])/
+          {
+            type: type
+          }
+        when /(modified|modifié|modifiée|modifiés|MOD)\s*[–-–]?\s+(.+)\Z/
+          {
+            type: type,
+            modification: $LAST_MATCH_INFO[2]
+          }
+        else
+          {
+            type: type
+          }
+        end
+      end
 
-        clause = source.
-          gsub(clean_ref, "").
-          gsub(/\A,?\s+/,"").
-          strip
+      def extract_single_source(raw_ref)
+        # source = "ISO/IEC GUIDE 99:2007 1.26"
+        # raw_ref = str.match(/\A[^,\()]+/).to_s
+
+        puts "[extract_single_source] #{raw_ref}"
+
+        relation_type = extract_source_relationship(raw_ref)
+
+        # définition 3.60 de la 62127-1
+        # definition 3.60 of 62127-1
+        # définition 3.60 de la 62127-1
+        # definition 3.7 of IEC 62127-1 MOD, adapted from 4.2.9 of IEC 61828 and 3.6 of IEC 61102
+        # définition 3.7 de la CEI 62127-1 MOD, adaptées sur la base du 4.2.9 de la CEI 61828 et du 3.6 de la CEI 61102
+        # definition 3.54 of 62127-1 MOD
+        # définition 3.54 de la CEI 62127-1 MOD
+        # IEC 62313:2009, 3.6, modified
+        # IEC 62313:2009, 3.6, modifié
+
+        clean_ref = raw_ref
+          .gsub(/CEI/, "IEC")
+          .gsub(/Guide IEC/, "IEC Guide")
+          .gsub(/Guide ISO\/IEC/, "ISO/IEC Guide")
+          .gsub(/VEI/, "IEV")
+          .gsub(/UIT/, "ITU")
+          .gsub(/IUT-R/, "ITU-R")
+          .gsub(/UTI-R/, "ITU-R")
+          .gsub(/Recomm[ea]ndation ITU-T/, "ITU-T Recommendation")
+          .gsub(/ITU-T (\w.\d{3}):(\d{4})/, 'ITU-T Recommendation \1 (\2)')
+          .gsub(/ITU-R Rec. (\d+)/, 'ITU-R Recommendation \1')
+          .gsub(/[≈≠]\s+/, "")
+          .sub(/ИЗМ\Z/, "MOD")
+          .sub(/definition ([\d\.]+) of ([\d\-\:]+) MOD/, 'IEC \2, \1, modified - ')
+          .sub(/definition ([\d\.]+) of IEC ([\d\-\:]+) MOD/, 'IEC \2, \1, modified - ')
+          .sub(/définition ([\d\.]+) de la ([\d\-\:]+) MOD/, 'IEC \2, \1, modified - ')
+          .sub(/définition ([\d\.]+) de la IEC ([\d\-\:]+) MOD/, 'IEC \2, \1, modified - ')
+          .sub(/(\d{3})\ (\d{2})\ (\d{2})/, '\1-\2-\3')  # for 221 04 03
+
+          # .sub(/\A(from|d'après|voir la|see|See|voir|Voir)\s+/, "")
+
+        source_ref = extract_source_ref(clean_ref)
+          .sub(/, modifi(ed|é)\Z/, "")
+          .strip
+
+        clause = extract_source_clause(clean_ref)
+
+        # puts "CLAUSENIL!!! #{raw_ref}" if clause.nil?
+        # puts "SOURCE!!! #{raw_ref}" if source_ref.nil?
+
+        # puts "[RAW] #{raw_ref}"
+        h = {
+          source_ref: source_ref,
+          clause: clause,
+          relation_type: relation_type
+        }
+
+        pp h
 
         item = ::Iev::Termbase::RelatonDb.instance.fetch(clean_ref)
 
         src = {}
-        src["ref"] = clean_ref
-        src["clause"] = clause unless clause.empty?
+
+        src["ref"] = source_ref
+        src["clause"] = clause if clause
         src["link"] = item.url if item
-        src["type"] = relation_type
+        src["relationship"] = relation_type
+        src["original"] = raw_ref
+
         src
       rescue ::RelatonBib::RequestError => e
         warn e.message
       end
 
-      # Cleans up ref string, removes unnecessary junk, fixes common typos,
-      # canonicalizes alternative names, etc.
-      def clean_ref_string(str)
-        str = str.dup
+      def extract_authoritative_source
+        source = find_value_for("SOURCE")
 
-        str.gsub!("&nbsp;", " ")
-        str.sub!(";", ":")
-        str.sub!(/\A(from|d'après|voir la|see|See|voir|Voir|definition\s+of|définition\s+de\s+la)\s+/, "")
-        str.sub!(/\ASI Brochure\Z/, "BIPM SI Brochure")
-        str.sub!(/\ABrochure sur le SI\Z/, "BIPM SI Brochure")
-        str.sub!(/\ MOD/, "")
-        str.sub!(/MOD\ /, "")
-        str.sub!(/\A(\d{2,3}-\d{2,3}-\d{2,3})/, 'IEV \1')
-        str.sub!(/IEV part\s+(\d+)/, 'IEC 60500-\1')
-        str.sub!(/partie\s+(\d+)\s+de l'IEV/, 'IEC 60500-\1')
-        str.sub!(/IEC\sIEEE/, "IEC/IEEE")
-        str.sub!(/\AVEI/, "IEV")
-        str.sub!(/\AAIEA/, "IAEA")
-        str.sub!(/UIT/, "ITU")
-        str.sub!(/UTI-R/, "ITU-R")
-        str.sub!(/Recomm[ea]ndation ITU-T/, "ITU-T Recommendation")
-        str.sub!(/ITU-T (\w.\d{3}):(\d{4})/, 'ITU-T \1 (\2)')
-        str.sub!(/CEI/, "IEC")
-        str.sub!(/\AGuide IEC/, "IEC Guide")
-        str.sub!(/\AGuide ISO\/IEC/, "ISO/IEC Guide")
-        str.sub!(/\d\.[\d\.]+/, "")
-        str.strip!
-        str
+        return nil if source.nil?
+
+        source = HTMLEntities.new.decode(source).gsub("\u00a0", " ")
+
+        puts "[RAW] #{source}"
+
+        # IEC 62047-22:2014, 3.1.1, modified – In the definition, "the product of" has been added. Note 1 to entry has been deleted; its content is now part of the definition.
+        source = source
+          .gsub(/;\s?([A-Z][A-Z])/, ';; \1')
+          .gsub(/MOD[,\.]/, 'MOD;;')
+
+        # "702-01-02 MOD,ITU-R Rec. 431 MOD"
+        # 702-09-44 MOD, 723-07-47, voir 723-10-91
+        # definition 3.7 of IEC 62127-1 MOD, adapted from 4.2.9 of IEC 61828 and 3.6 of IEC 61102
+        # définition 3.7 de la CEI 62127-1 MOD, adaptées sur la base du 4.2.9 de la CEI 61828 et du 3.6 de la CEI 61102
+        # 161-06-01 MOD. ITU RR 139 MOD
+        source = source
+          .gsub(/MOD,\s*([UIC\d])/, 'MOD;; \1')
+          .gsub(/MOD[,\.]/, 'MOD;;')
+
+        # IEC 62303:2008, 3.1, modified and IEC 62302:2007, 3.2; IAEA 4
+        # CEI 62303:2008, 3.1, modifiée et CEI 62302:2007, 3.2; AIEA 4
+
+        source = source
+          .gsub(/modified and IEC/, "modified;; IEC")
+          .gsub(/modifiée et CEI/, "modifiée;; IEC")
+
+        # 725-12-50, ITU RR 11
+        source = source.gsub(/,\s+ITU/, ";; ITU")
+
+        # 705-02-01, 702-02-07
+        source = source.gsub(/(\d{2,3}-\d{2,3}-\d{2,3}),\s*(\d{2,3}-\d{2,3}-\d{2,3})/, '\1;; \2')
+
+        sources = source.split(';;').map(&:strip)
+
+        sources.map do |src|
+          extract_single_source(src)
+        end
       end
 
       SIMG_PATH_REGEX = "<simg .*\\/\\$file\\/([\\d\\-\\w\.]+)>"

--- a/lib/iev/termbase/term_builder.rb
+++ b/lib/iev/termbase/term_builder.rb
@@ -384,15 +384,11 @@ module Iev
       end
 
       def extract_source_ref(str)
-
-        # ISO/IEC 2382:2015 (https://www.iso.org/obp/ui/#iso:std:iso-iec:2382:ed-1:v1:en), 2126371, modified – Notes 1 to 3 to entry have been omitted.
-
-
         case str
         when /SI Brochure/, /Brochure sur le SI/
-          # "SI Brochure, 9th edition, 2019, 2.3.1, modified – The definition from the SI Brochure has been adapted to comply with the IEV rules. Notes 1 to 4 to entry have been added."
-          # SI Brochure, 9th edition, 2019, Appendix 1, modified – The definition in the SI Brochure has been revised to comply with the IEV rules. The synonym "Loschmidt number" and the symbol "<i>L</i>" have been added to Note 2 to entry.
-          # Brochure sur le SI, 9<sup>e</sup> édition, 2019, Annexe 1, modifié – La définition d e la Brochure sur le SI a été révisée à des fins de mise en conformité avec les règles de l’IEV. Le synonyme "nombre de Loschmidt" et le symbole "<i>L</i>" ont été ajoutés dans la Note 2 à l’article.
+          # SI Brochure, 9th edition, 2019, 2.3.1
+          # SI Brochure, 9th edition, 2019, Appendix 1
+          # Brochure sur le SI, 9<sup>e</sup> édition, 2019, Annexe 1
           "BBIPM SI Brochure TEMP DISABLED DUE TO RELATON"
 
         when /VIM/
@@ -472,7 +468,6 @@ module Iev
       end
 
       def extract_source_clause(str)
-
         # Strip out the modifications
         str = str.sub(/[,\ ]*modif.+\s[-–].*\Z/, "")
 
@@ -496,21 +491,20 @@ module Iev
           # 221 04 03
           [/(\d{3}\ \d{2}\ \d{2})/, "1"],
           # ", 1.1"
+
           # "SI Brochure, 9th edition, 2019, 2.3.1,"
           [/,\s?(\d+\.[\d\.]+)/, "1"],
-
-          #  CLAUSENIL!!! SI Brochure, 9th edition, 2019, Appendix 1, modified
+          #  SI Brochure, 9th edition, 2019, Appendix 1, modified
+          #  Brochure sur le SI, 9<sup>e</sup> édition, 2019, Annexe 1,
           [/\d{4}, (Appendix \d)/, "1"],
-
-          #  CLAUSENIL!!! Brochure sur le SI, 9<sup>e</sup> édition, 2019, Annexe 1,
           [/\d{4}, (Annexe \d)/, "1"],
 
-          #  International Telecommunication Union (ITU) Constitution (Ed. 2015), No. 1012 of the Annex,
+          # International Telecommunication Union (ITU) Constitution (Ed. 2015), No. 1012 of the Annex,
           # Constitution de l’Union internationale des télécommunications (UIT) (Ed. 2015), N° 1012 de l’Annexe,
           [/, (No. \d{4} of the Annex)/, "1"],
           [/, (N° \d{4} 1012 de l’Annexe)/, "1"],
 
-          # ISO/IEC 2382:2015 (https://www.iso.org/obp/ui/#iso:std:iso-iec:2382:ed-1:v1:en), 2126371,
+          # ISO/IEC 2382:2015 (https://www.iso.org/obp/ui/#iso:std:iso-iec:2382:ed-1:v1:en), 2126371
           [/\), (\d{7}),/, "1"],
 
           # " 1.1 "
@@ -678,20 +672,19 @@ module Iev
 
         puts "[RAW] #{source}"
 
-        # IEC 62047-22:2014, 3.1.1, modified – In the definition, "the product of" has been added. Note 1 to entry has been deleted; its content is now part of the definition.
+        # IEC 62047-22:2014, 3.1.1, modified – In the definition, ...
         source = source
           .gsub(/;\s?([A-Z][A-Z])/, ';; \1')
           .gsub(/MOD[,\.]/, 'MOD;;')
 
-        # "702-01-02 MOD,ITU-R Rec. 431 MOD"
-        # 702-09-44 MOD, 723-07-47, voir 723-10-91
-        # definition 3.7 of IEC 62127-1 MOD, adapted from 4.2.9 of IEC 61828 and 3.6 of IEC 61102
-        # définition 3.7 de la CEI 62127-1 MOD, adaptées sur la base du 4.2.9 de la CEI 61828 et du 3.6 de la CEI 61102
+        # 702-01-02 MOD,ITU-R Rec. 431 MOD
         # 161-06-01 MOD. ITU RR 139 MOD
         source = source
           .gsub(/MOD,\s*([UIC\d])/, 'MOD;; \1')
           .gsub(/MOD[,\.]/, 'MOD;;')
 
+        # TODO
+        # 702-09-44 MOD, 723-07-47, voir 723-10-91
         # IEC 62303:2008, 3.1, modified and IEC 62302:2007, 3.2; IAEA 4
         # CEI 62303:2008, 3.1, modifiée et CEI 62302:2007, 3.2; AIEA 4
 

--- a/spec/iev/termbase/term_builder_spec.rb
+++ b/spec/iev/termbase/term_builder_spec.rb
@@ -1,0 +1,96 @@
+require "spec_helper"
+
+RSpec.describe Iev::Termbase::TermBuilder do
+
+  let(:builder) {
+    Iev::Termbase::TermBuilder.new(data: {}, indices: {})
+  }
+
+  describe ".split_source_field" do
+
+    it "parses 'MOD,ITU" do
+      phrase = "702-01-02 MOD,ITU-R Rec. 431 MOD"
+      results = builder.split_source_field(phrase)
+
+      expect(results.class).to be(Array)
+      expect(results.size).to eq(2)
+
+      results.each do |r|
+        expect([ "702-01-02 MOD", "ITU-R Rec. 431 MOD" ]).to include(r)
+      end
+    end
+  end
+
+  it "parses 'MOD. ITU" do
+    phrase = "161-06-01 MOD. ITU RR 139 MOD"
+    results = builder.split_source_field(phrase)
+
+    expect(results.class).to be(Array)
+    expect(results.size).to eq(2)
+
+    results.each do |r|
+      expect([ "161-06-01 MOD", "ITU RR 139 MOD" ]).to include(r)
+    end
+  end
+
+  it "parses 'XXX-XX-XX, ITU" do
+    phrase = "725-12-50, ITU RR 11"
+    results = builder.split_source_field(phrase)
+
+    expect(results.class).to be(Array)
+    expect(results.size).to eq(2)
+
+    results.each do |r|
+      expect([ "725-12-50", "ITU RR 11" ]).to include(r)
+    end
+  end
+
+  it "parses 'XXX-XX-XX, YYY-YY-YY" do
+    phrase = "705-02-01, 702-02-07"
+    results = builder.split_source_field(phrase)
+
+    expect(results.class).to be(Array)
+    expect(results.size).to eq(2)
+
+    results.each do |r|
+      expect([ "705-02-01", "702-02-07" ]).to include(r)
+    end
+  end
+
+  it "parses '702-09-44 MOD, 723-07-47, voir 723-10-91" do
+    phrase = "702-09-44 MOD, 723-07-47, voir 723-10-91"
+    results = builder.split_source_field(phrase)
+
+    expect(results.class).to be(Array)
+    expect(results.size).to eq(3)
+
+    results.each do |r|
+      expect([ "702-09-44 MOD", "723-07-47", "voir 723-10-91" ]).to include(r)
+    end
+  end
+
+  it "parses 'IEC 62303:2008, 3.1, modified and IEC 62302:2007, 3.2; IAEA 4" do
+    phrase = "IEC 62303:2008, 3.1, modified and IEC 62302:2007, 3.2; IAEA 4"
+    results = builder.split_source_field(phrase)
+
+    expect(results.class).to be(Array)
+    expect(results.size).to eq(3)
+
+    results.each do |r|
+      expect([ "IEC 62303:2008, 3.1, modified", "IEC 62302:2007, 3.2", "IAEA 4" ]).to include(r)
+    end
+  end
+
+  it "parses 'CEI 62303:2008, 3.1, modifiée et CEI 62302:2007, 3.2; AIEA 4" do
+    phrase = "CEI 62303:2008, 3.1, modifiée et CEI 62302:2007, 3.2; AIEA 4"
+    results = builder.split_source_field(phrase)
+
+    expect(results.class).to be(Array)
+    expect(results.size).to eq(3)
+
+    results.each do |r|
+      expect([ "CEI 62303:2008, 3.1, modifiée", "CEI 62302:2007, 3.2", "AIEA 4" ]).to include(r)
+    end
+  end
+
+end


### PR DESCRIPTION
This PR handles all SOURCE entries in the IEV dataset properly, except for these three types:

```
# We need to seek clarification on what these actually mean...
[extract_single_source] see IEC 60050-131, IEC 61293, IEC 60417 item 5031
{:source_ref=>"IEC 60050-131", :clause=>nil, :relation_type=>{:type=>:related}}
[extract_single_source] voir la CEI 60050-131, CEI 61293, CEI 60417, N°5031
{:source_ref=>"IEC 60050-131", :clause=>nil, :relation_type=>{:type=>:related}}

# These should be split into "ISO/IEC Guide 2, 14.4 MOD; 191-14-02 MOD"
[extract_single_source] ISO/IEC Guide 2 (14.4 MOD), 191-14-02 MOD
{:source_ref=>"IEV", :clause=>"14.4", :relation_type=>{:type=>:modified}}
[extract_single_source] ISO/CEI Guide 2 (14.4 MOD), 191-14-02 MOD
{:source_ref=>"IEV", :clause=>"14.4", :relation_type=>{:type=>:modified}}

# These should be split into "ISO 921:1997, definition 453, modified; ISO 921:1997 definition 483, modified"
[extract_single_source] ISO 921:1997, definition 453, modified and definition 483, modified
{:source_ref=>"ISO 921:1997",
[extract_single_source] ISO 921:1997, définition 453, modifiée et définition 483, modifiée
```
