### PR TITLE
Rework term attributes parser

### DIFF
--- a/lib/iev/termbase/nested_term_builder.rb
+++ b/lib/iev/termbase/nested_term_builder.rb
@@ -1,3 +1,5 @@
+require "iev/termbase/term_attrs_parser"
+
 module Iev
   module Termbase
     class NestedTermBuilder
@@ -22,75 +24,24 @@ module Iev
       attr_reader :data, :status, :options
 
       def term_attributes
-        @term_attributes ||= HTMLEntities.new(:expanded).decode(data.to_s) || ""
+        @term_attributes ||= TermAttrsParser.new(data.to_s)
       end
 
       def build_nested_term
         {
           "type" => options[:type],
-          "prefix" => extract_prefix,
+          "prefix" => term_attributes.extract_prefix,
           "normative_status" => term_status,
-          "usage_info" => extract_usage_info,
+          "usage_info" => term_attributes.extract_usage_info,
           "designation" => options[:term],
-          "part_of_speech" => extract_part_of_speech,
-          "geographical_area" => extract_geographical_area,
+          "part_of_speech" => term_attributes.extract_part_of_speech,
+          "geographical_area" => term_attributes.extract_geographical_area,
           "international" => options.fetch(:international, nil),
-        }.merge(extract_gender || {})
+        }.merge(term_attributes.extract_gender || {})
       end
 
       def term_status
         status.downcase if status
-      end
-
-      def extract_gender
-        genders = term_attributes.match(/\s([m|f|n])$|^([m|f|n])[\s,]?|([m|f|n]) (pl)/)
-
-        if genders
-          plurality = "singular"
-          gender = genders[1..3].join('')
-          plurality = "plural" if genders.size > 1 && genders[4] == "pl"
-
-          { "gender" => gender, "plurality" => plurality }
-        end
-      end
-
-      def parts_hash
-        @parts_hash ||= {
-          "名詞" => "noun",
-          "動詞" => "verb",
-          "形容詞" => "adj",
-          "형용사" => "adj",
-          "Adjektiv" => "adj",
-        }
-      end
-
-      def extract_geographical_area
-        area = term_attributes.match(/([A-Z]{2})$/)
-        if area && area.size > 1
-          area[1]
-        end
-      end
-
-      def extract_part_of_speech
-        parts_regex = /noun|名詞|verb|動詞|Adjektiv|adj|形容詞|형용사/
-        part_of_speeches = term_attributes.match(parts_regex)
-
-        if part_of_speeches
-          part_of_speech = part_of_speeches[1]
-          parts_hash[part_of_speech] || part_of_speech
-        end
-      end
-
-      def extract_usage_info
-        usage_info = term_attributes.match(/<(.*?)>/)
-
-        if usage_info && usage_info.size > 1
-          usage_info[1].strip
-        end
-      end
-
-      def extract_prefix
-        term_attributes.match(/Präfix|prefix|préfixe|接尾語|접두사|przedrostek|prefixo|词头/) ? true : nil
       end
     end
   end

--- a/lib/iev/termbase/nested_term_builder.rb
+++ b/lib/iev/termbase/nested_term_builder.rb
@@ -32,7 +32,7 @@ module Iev
           "normative_status" => term_status,
           "usage_info" => extract_usage_info,
           "designation" => options[:term],
-          "part_of_speech" => extract_part_of_speach,
+          "part_of_speech" => extract_part_of_speech,
           "geographical_area" => extract_geographical_area,
           "international" => options.fetch(:international, nil),
         }.merge(extract_gender || {})
@@ -71,13 +71,13 @@ module Iev
         end
       end
 
-      def extract_part_of_speach
+      def extract_part_of_speech
         parts_regex = /noun|名詞|verb|動詞|Adjektiv|adj|形容詞|형용사/
-        part_of_speaches = term_attributes.match(parts_regex)
+        part_of_speeches = term_attributes.match(parts_regex)
 
-        if part_of_speaches
-          part_of_speach = part_of_speaches[1]
-          parts_hash[part_of_speach] || part_of_speach
+        if part_of_speeches
+          part_of_speech = part_of_speeches[1]
+          parts_hash[part_of_speech] || part_of_speech
         end
       end
 

--- a/lib/iev/termbase/nested_term_builder.rb
+++ b/lib/iev/termbase/nested_term_builder.rb
@@ -30,14 +30,16 @@ module Iev
       def build_nested_term
         {
           "type" => options[:type],
-          "prefix" => term_attributes.extract_prefix,
+          "prefix" => term_attributes.prefix,
           "normative_status" => term_status,
-          "usage_info" => term_attributes.extract_usage_info,
+          "usage_info" => term_attributes.usage_info,
           "designation" => options[:term],
-          "part_of_speech" => term_attributes.extract_part_of_speech,
-          "geographical_area" => term_attributes.extract_geographical_area,
+          "part_of_speech" => term_attributes.part_of_speech,
+          "geographical_area" => term_attributes.geographical_area,
           "international" => options.fetch(:international, nil),
-        }.merge(term_attributes.extract_gender || {})
+          "gender" => term_attributes.gender,
+          "plurality" => term_attributes.plurality,
+        }
       end
 
       def term_status

--- a/lib/iev/termbase/term_attrs_parser.rb
+++ b/lib/iev/termbase/term_attrs_parser.rb
@@ -78,10 +78,10 @@ module Iev
       end
 
       def extract_usage_info
-        usage_info = src_str.match(/<(.*?)>/)
+        info_rx = /<(.*?)>/
 
-        if usage_info && usage_info.size > 1
-          @usage_info = usage_info[1].strip
+        if info_rx =~ src_str
+          @usage_info = $~[1].strip
         end
       end
 

--- a/lib/iev/termbase/term_attrs_parser.rb
+++ b/lib/iev/termbase/term_attrs_parser.rb
@@ -58,10 +58,12 @@ module Iev
         end
       end
 
+      # TODO this is likely buggy
       def extract_geographical_area
-        area = src_str.match(/([A-Z]{2})$/)
-        if area && area.size > 1
-          @geographical_area = area[1]
+        ga_rx = /\b[A-Z]{2}$/
+
+        if ga_rx =~ src_str
+          @geographical_area = $&
         end
       end
 

--- a/lib/iev/termbase/term_attrs_parser.rb
+++ b/lib/iev/termbase/term_attrs_parser.rb
@@ -20,6 +20,7 @@ module Iev
 
       def parse
         extract_gender
+        extract_plurality
         extract_geographical_area
         extract_part_of_speech
         extract_usage_info
@@ -27,12 +28,22 @@ module Iev
       end
 
       def extract_gender
-        genders = src_str.match(/\s([m|f|n])$|^([m|f|n])[\s,]?|([m|f|n]) (pl)/)
+        gender_rx = /\b[mfn]\b/
 
-        if genders
+        if gender_rx =~ src_str
+          @gender = $&
+        end
+      end
+
+      # Must happen after #extract_gender
+      def extract_plurality
+        plural_rx = /\bpl\b/
+
+        if plural_rx =~ src_str
+          @plurality = "plural"
+        elsif !gender.nil?
+          # TODO Really needed?
           @plurality = "singular"
-          @gender = genders[1..3].join('')
-          @plurality = "plural" if genders.size > 1 && genders[4] == "pl"
         end
       end
 

--- a/lib/iev/termbase/term_attrs_parser.rb
+++ b/lib/iev/termbase/term_attrs_parser.rb
@@ -5,7 +5,7 @@ module Iev
 
       def initialize(attr_str)
         @raw_str = attr_str.dup.freeze
-        @src_str = (HTMLEntities.new(:expanded).decode(attr_str) || "").freeze
+        @src_str = decode_attrs_string(raw_str).freeze
       end
 
       def inspect
@@ -61,6 +61,12 @@ module Iev
 
       def extract_prefix
         src_str.match(/Präfix|prefix|préfixe|接尾語|접두사|przedrostek|prefixo|词头/) ? true : nil
+      end
+
+    private
+
+      def decode_attrs_string(str)
+        HTMLEntities.new(:expanded).decode(str) || ""
       end
     end
   end

--- a/lib/iev/termbase/term_attrs_parser.rb
+++ b/lib/iev/termbase/term_attrs_parser.rb
@@ -17,6 +17,10 @@ module Iev
         "Adjektiv" => "adj",
       }.freeze
 
+      PREFIX_KEYWORDS = %w[
+        Präfix prefix préfixe 接尾語 접두사 przedrostek prefixo 词头
+      ].freeze
+
       def initialize(attr_str)
         @raw_str = attr_str.dup.freeze
         @src_str = decode_attrs_string(raw_str).freeze
@@ -88,7 +92,15 @@ module Iev
       end
 
       def extract_prefix
-        @prefix = src_str.match(/Präfix|prefix|préfixe|接尾語|접두사|przedrostek|prefixo|词头/) ? true : nil
+        prefix_rx = %r{
+          \b
+          #{Regexp.union(PREFIX_KEYWORDS)}
+          \b
+        }x.freeze
+
+        if prefix_rx =~ src_str
+          @prefix = true
+        end
       end
 
       def decode_attrs_string(str)

--- a/lib/iev/termbase/term_attrs_parser.rb
+++ b/lib/iev/termbase/term_attrs_parser.rb
@@ -6,6 +6,17 @@ module Iev
       attr_reader :gender, :geographical_area, :part_of_speech, :plurality,
         :prefix, :usage_info
 
+      PARTS_OF_SPEECH = {
+        "adj" => "adj",
+        "noun" => "noun",
+        "verb" => "verb",
+        "名詞" => "noun",
+        "動詞" => "verb",
+        "形容詞" => "adj",
+        "형용사" => "adj",
+        "Adjektiv" => "adj",
+      }.freeze
+
       def initialize(attr_str)
         @raw_str = attr_str.dup.freeze
         @src_str = decode_attrs_string(raw_str).freeze
@@ -47,16 +58,6 @@ module Iev
         end
       end
 
-      def parts_hash
-        @parts_hash ||= {
-          "名詞" => "noun",
-          "動詞" => "verb",
-          "形容詞" => "adj",
-          "형용사" => "adj",
-          "Adjektiv" => "adj",
-        }
-      end
-
       def extract_geographical_area
         area = src_str.match(/([A-Z]{2})$/)
         if area && area.size > 1
@@ -65,12 +66,14 @@ module Iev
       end
 
       def extract_part_of_speech
-        parts_regex = /noun|名詞|verb|動詞|Adjektiv|adj|形容詞|형용사/
-        part_of_speeches = src_str.match(parts_regex)
+        pos_rx = %r{
+          \b
+          #{Regexp.union(PARTS_OF_SPEECH.keys)}
+          \b
+        }x.freeze
 
-        if part_of_speeches
-          part_of_speech = part_of_speeches[1]
-          @part_of_speech = parts_hash[part_of_speech] || part_of_speech
+        if pos_rx =~ src_str
+          @part_of_speech = PARTS_OF_SPEECH[$&] || $&
         end
       end
 

--- a/lib/iev/termbase/term_attrs_parser.rb
+++ b/lib/iev/termbase/term_attrs_parser.rb
@@ -1,0 +1,67 @@
+module Iev
+  module Termbase
+    class TermAttrsParser
+      attr_reader :raw_str, :src_str
+
+      def initialize(attr_str)
+        @raw_str = attr_str.dup.freeze
+        @src_str = (HTMLEntities.new(:expanded).decode(attr_str) || "").freeze
+      end
+
+      def inspect
+        "<ATTRIBUTES: #{src_str}>".freeze
+      end
+
+      def extract_gender
+        genders = src_str.match(/\s([m|f|n])$|^([m|f|n])[\s,]?|([m|f|n]) (pl)/)
+
+        if genders
+          plurality = "singular"
+          gender = genders[1..3].join('')
+          plurality = "plural" if genders.size > 1 && genders[4] == "pl"
+
+          { "gender" => gender, "plurality" => plurality }
+        end
+      end
+
+      def parts_hash
+        @parts_hash ||= {
+          "名詞" => "noun",
+          "動詞" => "verb",
+          "形容詞" => "adj",
+          "형용사" => "adj",
+          "Adjektiv" => "adj",
+        }
+      end
+
+      def extract_geographical_area
+        area = src_str.match(/([A-Z]{2})$/)
+        if area && area.size > 1
+          area[1]
+        end
+      end
+
+      def extract_part_of_speech
+        parts_regex = /noun|名詞|verb|動詞|Adjektiv|adj|形容詞|형용사/
+        part_of_speeches = src_str.match(parts_regex)
+
+        if part_of_speeches
+          part_of_speech = part_of_speeches[1]
+          parts_hash[part_of_speech] || part_of_speech
+        end
+      end
+
+      def extract_usage_info
+        usage_info = src_str.match(/<(.*?)>/)
+
+        if usage_info && usage_info.size > 1
+          usage_info[1].strip
+        end
+      end
+
+      def extract_prefix
+        src_str.match(/Präfix|prefix|préfixe|接尾語|접두사|przedrostek|prefixo|词头/) ? true : nil
+      end
+    end
+  end
+end

--- a/spec/iev/termbase/terms_attrs_parser_spec.rb
+++ b/spec/iev/termbase/terms_attrs_parser_spec.rb
@@ -187,4 +187,51 @@ RSpec.describe Iev::Termbase::TermAttrsParser do
     end
   end
 
+  describe "prefix" do
+    example "Präfix" do
+      expect(subject.prefix).to be(true)
+    end
+
+    example "prefix" do
+      expect(subject.prefix).to be(true)
+    end
+
+    example "préfixe" do
+      expect(subject.prefix).to be(true)
+    end
+
+    example "接尾語" do
+      expect(subject.prefix).to be(true)
+    end
+
+    example "접두사" do
+      expect(subject.prefix).to be(true)
+    end
+
+    example "przedrostek" do
+      expect(subject.prefix).to be(true)
+    end
+
+    example "prefixo" do
+      expect(subject.prefix).to be(true)
+    end
+
+    example "词头" do
+      expect(subject.prefix).to be(true)
+    end
+
+    it "works for empty strings", string: "" do
+      expect(subject.prefix).to be(nil)
+    end
+
+    it "works for strings which do not specify prefix",
+      string: "a whatever" do
+      expect(subject.prefix).to be(nil)
+    end
+
+    it "is not fooled with longer words",
+      string: "prefixed" do
+      expect(subject.prefix).to be(nil)
+    end
+  end
 end

--- a/spec/iev/termbase/terms_attrs_parser_spec.rb
+++ b/spec/iev/termbase/terms_attrs_parser_spec.rb
@@ -135,4 +135,28 @@ RSpec.describe Iev::Termbase::TermAttrsParser do
       expect(subject.part_of_speech).to be(nil)
     end
   end
+
+  describe "usage info" do
+    it "a string <info>" do
+      expect(subject.usage_info).to eq("info")
+    end
+
+    it "<only info>" do
+      expect(subject.usage_info).to eq("only info")
+    end
+
+    it "<  info with extra spaces\t>" do
+      expect(subject.usage_info).to eq("info with extra spaces")
+    end
+
+    it "works for empty strings", string: "" do
+      expect(subject.usage_info).to be(nil)
+    end
+
+    it "works for strings which do not specify usage info",
+      string: "a whatever" do
+      expect(subject.usage_info).to be(nil)
+    end
+  end
+
 end

--- a/spec/iev/termbase/terms_attrs_parser_spec.rb
+++ b/spec/iev/termbase/terms_attrs_parser_spec.rb
@@ -159,4 +159,32 @@ RSpec.describe Iev::Termbase::TermAttrsParser do
     end
   end
 
+  describe "geographical area" do
+    example "US" do
+      expect(subject.geographical_area).to eq("US")
+    end
+
+    example "DE" do
+      expect(subject.geographical_area).to eq("DE")
+    end
+
+    it "requires capital letters", string: "us" do
+      expect(subject.geographical_area).to be(nil)
+    end
+
+    it "works for empty strings", string: "" do
+      expect(subject.geographical_area).to be(nil)
+    end
+
+    it "works for strings which do not specify area",
+      string: "a whatever" do
+      expect(subject.geographical_area).to be(nil)
+    end
+
+    it "is not fooled with longer words",
+      string: "THUS" do
+      expect(subject.geographical_area).to be(nil)
+    end
+  end
+
 end

--- a/spec/iev/termbase/terms_attrs_parser_spec.rb
+++ b/spec/iev/termbase/terms_attrs_parser_spec.rb
@@ -1,0 +1,87 @@
+RSpec.describe Iev::Termbase::TermAttrsParser do
+  # Parses :string metadata or example description.
+  subject do
+    example = RSpec.current_example
+    attributes_str = example.metadata[:string] || example.description
+    described_class.new(attributes_str)
+  end
+
+  describe "gender" do
+    example "f" do
+      expect(subject.gender).to eq("f")
+    end
+    example "m" do
+      expect(subject.gender).to eq("m")
+    end
+    example "n" do
+      expect(subject.gender).to eq("n")
+    end
+
+    it "works for empty strings", string: "" do
+      expect(subject.gender).to be(nil)
+    end
+
+    it "works for strings which do not specify gender", string: "a whatever" do
+      expect(subject.gender).to be(nil)
+    end
+
+    it "allows comma as a separator", string: "m, whatever" do
+      expect(subject.gender).to eq("m")
+    end
+
+    it "is not fooled with longer sentences (begin/end of word)",
+      string: "noun" do
+      expect(subject.gender).to be(nil)
+    end
+
+    pending "it cannot be placed inside brackets" # too difficult for now
+  end
+
+  describe "plurality" do
+    example "pl" do
+      expect(subject.plurality).to eq("plural")
+    end
+
+    example "f pl" do
+      expect(subject.plurality).to eq("plural")
+    end
+    example "m pl" do
+      expect(subject.plurality).to eq("plural")
+    end
+    example "n pl" do
+      expect(subject.plurality).to eq("plural")
+    end
+
+    it "works for empty strings", string: "" do
+      expect(subject.plurality).to be(nil)
+    end
+
+    it "works for strings which do not specify plurality",
+      string: "a whatever" do
+      expect(subject.plurality).to be(nil)
+    end
+
+    it "allows comma as a separator", string: "m,pl" do
+      expect(subject.plurality).to eq("plural")
+    end
+
+    it "is not fooled with longer sentences (begin/end of word)",
+      string: "what a plapl" do
+      expect(subject.plurality).to be(nil)
+    end
+
+    it "always sets plurality if gender is specified", string: "f" do
+      expect(subject.plurality).to eq("singular")
+    end
+
+    it "always sets plurality if gender is specified", string: "m" do
+      expect(subject.plurality).to eq("singular")
+    end
+
+    it "always sets plurality if gender is specified", string: "n" do
+      expect(subject.plurality).to eq("singular")
+    end
+
+    pending "it cannot be placed inside brackets" # too difficult for now
+  end
+end

--- a/spec/iev/termbase/terms_attrs_parser_spec.rb
+++ b/spec/iev/termbase/terms_attrs_parser_spec.rb
@@ -84,4 +84,55 @@ RSpec.describe Iev::Termbase::TermAttrsParser do
 
     pending "it cannot be placed inside brackets" # too difficult for now
   end
+
+  describe "part of speech" do
+    example "adj" do
+      expect(subject.part_of_speech).to eq("adj")
+    end
+
+    example "noun" do
+      expect(subject.part_of_speech).to eq("noun")
+    end
+
+    example "verb" do
+      expect(subject.part_of_speech).to eq("verb")
+    end
+
+    example "名詞" do
+      expect(subject.part_of_speech).to eq("noun")
+    end
+
+    example "動詞" do
+      expect(subject.part_of_speech).to eq("verb")
+    end
+
+    example "形容詞" do
+      expect(subject.part_of_speech).to eq("adj")
+    end
+
+    example "형용사" do
+      expect(subject.part_of_speech).to eq("adj")
+    end
+
+    example "Adjektiv" do
+      expect(subject.part_of_speech).to eq("adj")
+    end
+
+    it "works for empty strings", string: "" do
+      expect(subject.part_of_speech).to be(nil)
+    end
+
+    it "works for strings which do not specify p.o.s.", string: "a whatever" do
+      expect(subject.part_of_speech).to be(nil)
+    end
+
+    it "allows comma as a separator", string: "adj, whatever" do
+      expect(subject.part_of_speech).to eq("adj")
+    end
+
+    it "is not fooled with longer sentences (begin/end of word)",
+      string: "adjunction radj" do
+      expect(subject.part_of_speech).to be(nil)
+    end
+  end
 end


### PR DESCRIPTION
Term attributes parser has been extracted to a separate class. Its source code quality has been improved, and tests have been added. Regular expressions have been cleaned-up, which fixed many unreported bugs.

This pull request does not solve all the issues with term parser, but is a great foundation to move forward.