### PR TITLE
Read synonym's term attributes from a proper XLS column

### DIFF
--- a/lib/iev/termbase/term_builder.rb
+++ b/lib/iev/termbase/term_builder.rb
@@ -187,7 +187,7 @@ module Iev
               type: "expression",
               term: mathml_to_asciimath(parse_anchor_tag(value)),
               data: find_value_for("SYNONYM#{num}ATTRIBUTE"),
-              status: find_value_for("SYNONYM1STATUS"),
+              status: find_value_for("SYNONYM#{num}STATUS"),
             ))
           end
         end


### PR DESCRIPTION
Fixes an obvious bug.