### PR TITLE
Fix failing spec

### DIFF
--- a/spec/iev/termbase/workbook_spec.rb
+++ b/spec/iev/termbase/workbook_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Iev::Termbase::Workbook do
       workbook = Iev::Termbase::Workbook.parse(sample_file)
 
       first_term = workbook.to_hash["103-01-01"]
-      kor_source = first_term["kor"]["authoritative_source"]
+      kor_source = first_term["kor"]["authoritative_source"][0]
 
       expect(workbook.size).to eq(2)
       expect(first_term["eng"]["id"]).to eq("103-01-01")


### PR DESCRIPTION
According to https://github.com/glossarist/iev-data/pull/74#issuecomment-755210860, `authoritative_source` is now an array.

This pull request fixes expectations on a failing spec.