### PR TITLE
Fix leading colons in authoritative sources

### DIFF
--- a/lib/iev/termbase/term_builder.rb
+++ b/lib/iev/termbase/term_builder.rb
@@ -569,16 +569,16 @@ module Iev
         case str
         when /^MOD ([\d\-])/
           {
-            "type" => type.to_s
+            "type" => type.to_s,
           }
         when /(modified|modifié|modifiée|modifiés|MOD)\s*[–-–]?\s+(.+)\Z/
           {
             "type" => type.to_s,
-            "modification" => $LAST_MATCH_INFO[2]
+            "modification" => $LAST_MATCH_INFO[2],
           }
         else
           {
-            "type" => type.to_s
+            "type" => type.to_s,
           }
         end
       end

--- a/lib/iev/termbase/term_builder.rb
+++ b/lib/iev/termbase/term_builder.rb
@@ -569,16 +569,16 @@ module Iev
         case str
         when /^MOD ([\d\-])/
           {
-            type: type
+            "type" => type.to_s
           }
         when /(modified|modifié|modifiée|modifiés|MOD)\s*[–-–]?\s+(.+)\Z/
           {
-            type: type,
-            modification: $LAST_MATCH_INFO[2]
+            "type" => type.to_s,
+            "modification" => $LAST_MATCH_INFO[2]
           }
         else
           {
-            type: type
+            "type" => type.to_s
           }
         end
       end


### PR DESCRIPTION
Serializing symbols to YAML resulted with prefixing them with odd and buggy colons.  Strings are better. Fixes #86.