### PR TITLE
Improve capturing stdout and stderr in specs

### DIFF
--- a/spec/acceptance/xlsx2yaml_spec.rb
+++ b/spec/acceptance/xlsx2yaml_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "IEV Termbase" do
   describe "xlsx2yaml" do
     it "parses xlsx document to yaml" do
       command = %W(xlsx2yaml #{sample_xlsx_file} -o ./tmp --no-write)
-      output = capture_stdout { Iev::Termbase::Cli.start(command) }
+      output, * = capture_output_streams { Iev::Termbase::Cli.start(command) }
 
       expect(output).to include("deu:")
       expect(output).to include("103-01-01:")

--- a/spec/iev/termbase/workbook_spec.rb
+++ b/spec/iev/termbase/workbook_spec.rb
@@ -2,8 +2,10 @@ require "spec_helper"
 
 RSpec.describe Iev::Termbase::Workbook do
   describe ".parse" do
+    subject { described_class.method(:parse) }
+
     it "parses to xls file to workbook" do
-      workbook = silence_output_streams { Iev::Termbase::Workbook.parse(sample_file) }
+      workbook = silence_output_streams { subject.(sample_file) }
 
       first_term = workbook.to_hash["103-01-01"]
       kor_source = first_term["kor"]["authoritative_source"][0]

--- a/spec/iev/termbase/workbook_spec.rb
+++ b/spec/iev/termbase/workbook_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe Iev::Termbase::Workbook do
   describe ".parse" do
     it "parses to xls file to workbook" do
-      workbook = Iev::Termbase::Workbook.parse(sample_file)
+      workbook = silence_output_streams { Iev::Termbase::Workbook.parse(sample_file) }
 
       first_term = workbook.to_hash["103-01-01"]
       kor_source = first_term["kor"]["authoritative_source"][0]

--- a/spec/support/console_helper.rb
+++ b/spec/support/console_helper.rb
@@ -1,29 +1,31 @@
 module Iev
   module ConsoleHelper
-    def capture_stdout(&_block)
+    # Executes given block.  Anything written to $stdout or $stderr in that
+    # block is captured and returned.
+    #
+    # @return Array - a three-element array composed of captured stdout,
+    #   captured stderr, and block's return value
+    def capture_output_streams
       original_stdout = $stdout
-      $stdout = fake = StringIO.new
+      original_stderr = $stderr
+      $stdout = fake_stdout = StringIO.new
+      $stderr = fake_stderr = StringIO.new
 
       begin
-        yield
+        block_return_value = yield
+        [fake_stdout.string, fake_stderr.string, block_return_value]
       ensure
         $stdout = original_stdout
-      end
-
-      fake.string
-    end
-
-    def capture_stderr(&_block)
-      original_stderr = $stderr
-      $stderr = fake = StringIO.new
-
-      begin
-        yield
-      ensure
         $stderr = original_stderr
       end
+    end
 
-      fake.string
+    # Executes given block.  Anything written to $stdout or $stderr in that
+    # block is suppressed.
+    #
+    # @return Object - block's return value
+    def silence_output_streams(&block)
+      capture_output_streams(&block)[2]
     end
   end
 end


### PR DESCRIPTION
This program prints some information to stdout and stderr. Proper stdout and stderr capturing is needed to get readable test results.  Also, some tests make expectations on what was written to stdout.

This pull request improves ease of use and quality of stdout and stderr capturing.