### PR TITLE
Extract most common data conversions as String class refinements

### DIFF
--- a/lib/iev/termbase/data_conversions.rb
+++ b/lib/iev/termbase/data_conversions.rb
@@ -25,6 +25,10 @@ module Iev
         def sanitize
           dup.tap(&:sanitize!)
         end
+
+        def to_three_char_code
+          Iev::Termbase::Iso639Code.three_char_code(self).first
+        end
       end
     end
   end

--- a/lib/iev/termbase/data_conversions.rb
+++ b/lib/iev/termbase/data_conversions.rb
@@ -2,6 +2,15 @@ module Iev
   module Termbase
     module DataConversions
       refine String do
+        def decode_html!
+          replace(decode_html)
+          nil
+        end
+
+        def decode_html
+          HTMLEntities.new(:expanded).decode(self)
+        end
+
         # Normalize various encoding anomalies like `\uFEFF` in strings
         def sanitize!
           unicode_normalize!

--- a/lib/iev/termbase/data_conversions.rb
+++ b/lib/iev/termbase/data_conversions.rb
@@ -1,0 +1,22 @@
+module Iev
+  module Termbase
+    module DataConversions
+      refine String do
+        # Normalize various encoding anomalies like `\uFEFF` in strings
+        def sanitize!
+          unicode_normalize!
+          gsub!("\uFEFF", "")
+          gsub!("\u2011", "-")
+          gsub!("\u00a0", " ")
+          strip!
+          nil
+        end
+
+        # @see sanitize!
+        def sanitize
+          dup.tap(&:sanitize!)
+        end
+      end
+    end
+  end
+end

--- a/lib/iev/termbase/term_attrs_parser.rb
+++ b/lib/iev/termbase/term_attrs_parser.rb
@@ -1,6 +1,8 @@
 module Iev
   module Termbase
     class TermAttrsParser
+      using DataConversions
+
       attr_reader :raw_str, :src_str
 
       attr_reader :gender, :geographical_area, :part_of_speech, :plurality,
@@ -104,7 +106,7 @@ module Iev
       end
 
       def decode_attrs_string(str)
-        HTMLEntities.new(:expanded).decode(str) || ""
+        str.decode_html || ""
       end
     end
   end

--- a/lib/iev/termbase/term_builder.rb
+++ b/lib/iev/termbase/term_builder.rb
@@ -38,7 +38,7 @@ module Iev
 
       def build_term_object
         row_term_id = find_value_for("IEVREF")
-        row_lang = three_char_code(find_value_for("LANGUAGE"))
+        row_lang = find_value_for("LANGUAGE").to_three_char_code
 
         print "\rProcessing term #{row_term_id} (#{row_lang})... "
 
@@ -124,10 +124,6 @@ module Iev
         definitions[:notes] = note_split[1..-1].map(&:strip) if note_split.size > 1
 
         definitions
-      end
-
-      def three_char_code(code)
-        Iev::Termbase::Iso639Code.three_char_code(code).first
       end
 
       def extract_terms

--- a/lib/iev/termbase/term_builder.rb
+++ b/lib/iev/termbase/term_builder.rb
@@ -3,6 +3,8 @@ require 'pp'
 module Iev
   module Termbase
     class TermBuilder
+      using DataConversions
+
       NOTE_REGEX_1 = /Note[\s ]*\d+[\s ]to entry:\s+|Note[\s ]*\d+?[\s ]à l['’]article:[\s ]*|<NOTE\/?>?[\s ]*\d?[\s ]+.*?–\s+|NOTE[\s ]+-[\s ]+/i
       NOTE_REGEX_2 = /\nNOTE\s+/
 
@@ -22,7 +24,7 @@ module Iev
       attr_reader :data, :indices
 
       def find_value_for(key)
-        clean_string(data.fetch(indices[key], nil))
+        data.fetch(indices[key], nil)&.sanitize
       end
 
       def flesh_date(incomplete_date)
@@ -32,19 +34,6 @@ module Iev
         # year and month
         year, month = incomplete_date.split('-')
         DateTime.parse("#{year}-#{month}-01").to_s
-      end
-
-      # Some IEV fields have the string `\uFEFF` polluting them
-      def clean_string(val)
-        return unless val
-
-        # u2011: issue iev-data#51
-        # u00a0: issue iev-data#50
-        val.unicode_normalize
-          .gsub("\uFEFF", "")
-          .gsub("\u2011", "-")
-          .gsub("\u00a0", " ")
-          .strip
       end
 
       def build_term_object
@@ -687,7 +676,7 @@ module Iev
 
         return nil if source_val.nil?
 
-        source_val = HTMLEntities.new.decode(source_val).gsub("\u00a0", " ")
+        source_val = HTMLEntities.new.decode(source_val).sanitize
 
         puts "[RAW] #{source_val}"
 

--- a/lib/iev/termbase/term_builder.rb
+++ b/lib/iev/termbase/term_builder.rb
@@ -183,7 +183,7 @@ module Iev
       end
 
       def text_to_asciimath(text)
-        html_entities_to_asciimath(HTMLEntities.new(:expanded).decode(text))
+        html_entities_to_asciimath(text.decode_html)
       end
 
       def html_to_asciimath(input)
@@ -676,7 +676,7 @@ module Iev
 
         return nil if source_val.nil?
 
-        source_val = HTMLEntities.new.decode(source_val).sanitize
+        source_val = source_val.decode_html.sanitize
 
         puts "[RAW] #{source_val}"
 

--- a/spec/iev/termbase/data_conversions_spec.rb
+++ b/spec/iev/termbase/data_conversions_spec.rb
@@ -3,6 +3,26 @@ require "spec_helper"
 RSpec.describe "string conversion refinements" do
   using Iev::Termbase::DataConversions
 
+  describe "#decode_html" do
+    it "decodes HTML entities" do
+      str = "&lt;b&gt;what a&lt;/b&gt; string &&amp; stuff"
+      expect(str.decode_html).to eq("<b>what a</b> string && stuff")
+    end
+
+    it "returns decoded string but leaves self unchanged" do
+      str = "&lt;&gt;"
+      expect { str.decode_html }.not_to change { str }
+      expect(str.decode_html).not_to eq(str)
+    end
+  end
+
+  describe "#decode_html!" do
+    it "decodes string in place" do
+      str = "&lt;&gt;"
+      expect { str.decode_html! }.to change { str }.to("<>")
+    end
+  end
+
   describe "#sanitize" do
     it "strips leading and trailing white spaces" do
       str = "  whatever\t"

--- a/spec/iev/termbase/data_conversions_spec.rb
+++ b/spec/iev/termbase/data_conversions_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+
+RSpec.describe "string conversion refinements" do
+  using Iev::Termbase::DataConversions
+
+  describe "#sanitize" do
+    it "strips leading and trailing white spaces" do
+      str = "  whatever\t"
+      expect(str.sanitize).to eq("whatever")
+    end
+
+    it "removes uFEFF sequences" do
+      str = "what\uFEFFever"
+      expect(str.sanitize).to eq("whatever")
+    end
+
+    it "replaces u2011 (non-breaking dashes) with regular dashes" do
+      str = "what\u2011ever"
+      expect(str.sanitize).to eq("what-ever")
+    end
+
+    it "replaces u00a0 with regular spaces" do
+      str = "what\u00a0ever"
+      expect(str.sanitize).to eq("what ever")
+    end
+
+    it "returns sanitized string but leaves self unchanged" do
+      str = "  what\uFEFFever\t"
+      expect { str.sanitize }.not_to change { str }
+      expect(str.sanitize).not_to eq(str)
+    end
+  end
+
+  describe "#sanitize!" do
+    it "sanitizes string in place" do
+      str = "  whatever\t"
+      expect { str.sanitize! }.to change { str }.to("whatever")
+    end
+  end
+end

--- a/spec/iev/termbase/data_conversions_spec.rb
+++ b/spec/iev/termbase/data_conversions_spec.rb
@@ -57,4 +57,18 @@ RSpec.describe "string conversion refinements" do
       expect { str.sanitize! }.to change { str }.to("whatever")
     end
   end
+
+  describe "#to_three_char_code" do
+    it "returns corresponding ISO 639-2 code for terminology" do
+      expect("en".to_three_char_code).to eq("eng")
+      expect("de".to_three_char_code).to eq("deu") # not ger
+    end
+
+    it "raises error when self is not a proper ISO 639-1 code" do
+      expect { "whatever".to_three_char_code }.to raise_error(StandardError)
+      expect { "xy".to_three_char_code }.to raise_error(StandardError)
+      # already ISO 639-2
+      expect { "eng".to_three_char_code }.to raise_error(StandardError)
+    end
+  end
 end


### PR DESCRIPTION
Following methods are being extracted:

- `String#sanitize`, which normalizes various Unicode oddities
- `String#decode_html`, which decodes HTML entities
- `String#to_three_char_code`, which handles language code conversion

This eliminates some copy-pasted logic. Also, newly defined methods are well-tested.

Maybe math conversion could be extracted too, but for now I don't want to touch it.