### PR TITLE
Simplify CLI

### DIFF
--- a/lib/iev/termbase/cli/command.rb
+++ b/lib/iev/termbase/cli/command.rb
@@ -8,7 +8,7 @@ module Iev::Termbase
         db = Sequel.sqlite
         DbWriter.new(db).import_spreadsheet(file)
         collection = ConceptCollection.build_from_dataset(db[:concepts])
-        write_to_file(file, collection, options)
+        save_collection_to_files(file, collection, options)
       end
 
       desc "xlsx2db FILE, DB_FILE", "Imports Excel to SQLite database."
@@ -24,12 +24,12 @@ module Iev::Termbase
       def db2yaml(dbfile)
         db = Sequel.sqlite(dbfile)
         collection = ConceptCollection.build_from_dataset(db[:concepts])
-        write_to_file(file, collection, options)
+        save_collection_to_files(file, collection, options)
       end
 
       private
 
-      def write_to_file(file, collection, options)
+      def save_collection_to_files(file, collection, options)
         output_dir = Pathname.new(options[:output].to_s)
 
         concept_dir = output_dir.join("concepts")

--- a/lib/iev/termbase/cli/command.rb
+++ b/lib/iev/termbase/cli/command.rb
@@ -8,7 +8,7 @@ module Iev::Termbase
         db = Sequel.sqlite
         DbWriter.new(db).import_spreadsheet(file)
         collection = ConceptCollection.build_from_dataset(db[:concepts])
-        save_collection_to_files(collection, options)
+        save_collection_to_files(collection, options[:output])
       end
 
       desc "xlsx2db FILE, DB_FILE", "Imports Excel to SQLite database."
@@ -24,13 +24,13 @@ module Iev::Termbase
       def db2yaml(dbfile)
         db = Sequel.sqlite(dbfile)
         collection = ConceptCollection.build_from_dataset(db[:concepts])
-        save_collection_to_files(collection, options)
+        save_collection_to_files(collection, options[:output])
       end
 
       private
 
-      def save_collection_to_files(collection, options)
-        output_dir = Pathname.new(options[:output].to_s)
+      def save_collection_to_files(collection, output_dir)
+        output_dir = Pathname.new(output_dir.to_s)
 
         concept_dir = output_dir.join("concepts")
         FileUtils.mkdir_p(concept_dir)

--- a/lib/iev/termbase/cli/command.rb
+++ b/lib/iev/termbase/cli/command.rb
@@ -33,7 +33,7 @@ module Iev::Termbase
         output_dir = Pathname.new(options[:output].to_s)
 
         concept_dir = output_dir.join("concepts")
-        FileUtils.mkdir_p(concept_dir)unless concept_dir.exist?
+        FileUtils.mkdir_p(concept_dir)
 
         collection.each do |key, concept|
           concept.to_file(concept_dir.join("concept-#{key}.yaml"))

--- a/lib/iev/termbase/cli/command.rb
+++ b/lib/iev/termbase/cli/command.rb
@@ -8,7 +8,7 @@ module Iev::Termbase
         db = Sequel.sqlite
         DbWriter.new(db).import_spreadsheet(file)
         collection = ConceptCollection.build_from_dataset(db[:concepts])
-        save_collection_to_files(file, collection, options)
+        save_collection_to_files(collection, options)
       end
 
       desc "xlsx2db FILE, DB_FILE", "Imports Excel to SQLite database."
@@ -24,12 +24,12 @@ module Iev::Termbase
       def db2yaml(dbfile)
         db = Sequel.sqlite(dbfile)
         collection = ConceptCollection.build_from_dataset(db[:concepts])
-        save_collection_to_files(file, collection, options)
+        save_collection_to_files(collection, options)
       end
 
       private
 
-      def save_collection_to_files(file, collection, options)
+      def save_collection_to_files(collection, options)
         output_dir = Pathname.new(options[:output].to_s)
 
         concept_dir = output_dir.join("concepts")

--- a/lib/iev/termbase/cli/command.rb
+++ b/lib/iev/termbase/cli/command.rb
@@ -31,7 +31,6 @@ module Iev::Termbase
 
       def write_to_file(file, collection, options)
         output_dir = Pathname.new(options[:output].to_s)
-        collection.to_file(collection_file_path(file, output_dir))
 
         concept_dir = output_dir.join("concepts")
         FileUtils.mkdir_p(concept_dir)unless concept_dir.exist?

--- a/lib/iev/termbase/cli/command.rb
+++ b/lib/iev/termbase/cli/command.rb
@@ -4,23 +4,11 @@ module Iev::Termbase
       desc "xlsx2yaml FILE", "Parsing Excel exports to IEV yaml."
       option :output, aliases: :o, default: Dir.pwd, desc: "Output directory"
 
-      option(
-        :write,
-        default: true,
-        type: :boolean,
-        desc: "Write or Stream to the output buffer",
-      )
-
       def xlsx2yaml(file)
         db = Sequel.sqlite
         DbWriter.new(db).import_spreadsheet(file)
         collection = ConceptCollection.build_from_dataset(db[:concepts])
-
-        if collection && options[:write]
-          write_to_file(file, collection, options)
-        else
-          UI.say(collection.to_yaml)
-        end
+        write_to_file(file, collection, options)
       end
 
       desc "xlsx2db FILE, DB_FILE", "Imports Excel to SQLite database."

--- a/spec/acceptance/xlsx2yaml_spec.rb
+++ b/spec/acceptance/xlsx2yaml_spec.rb
@@ -5,12 +5,28 @@ RSpec.describe "IEV Termbase" do
 
   describe "xlsx2yaml" do
     it "parses xlsx document to yaml" do
-      command = %W(xlsx2yaml #{sample_xlsx_file} -o ./tmp --no-write)
-      output, * = capture_output_streams { Iev::Termbase::Cli.start(command) }
+      Dir.mktmpdir("iev-test") do |dir|
+        command = %W(xlsx2yaml #{sample_xlsx_file} -o #{dir})
+        silence_output_streams { Iev::Termbase::Cli.start(command) }
 
-      expect(output).to include("deu:")
-      expect(output).to include("103-01-01:")
-      expect(output).to include("designation: 범함수")
+        concepts_dir = File.join(dir, "concepts")
+        expect(concepts_dir).to satisfy { |p| File.directory? p }
+        expect(Dir["#{concepts_dir}/concept-*.yaml"]).not_to be_empty
+
+        concept1 = File.read(File.join(concepts_dir, "concept-103-01-01.yaml"))
+        concept2 = File.read(File.join(concepts_dir, "concept-103-01-02.yaml"))
+
+        expect(concept1).to include("termid: 103-01-01")
+        expect(concept1).to include("term: function")
+        expect(concept1).to include("deu:")
+        expect(concept1).to include("designation: function")
+        expect(concept1).to include("release: 103-01-01:2009-12")
+
+        expect(concept2).to include("termid: 103-01-02")
+        expect(concept2).to include("term: functional")
+        expect(concept2).to include("deu:")
+        expect(concept2).to include("designation: 범함수")
+      end
     end
   end
 end


### PR DESCRIPTION
- Get rid of (probably) unused and buggy `--write`/`--no-write` option in CLI.
- Stop producing big YAML with all the concepts. Output directory with one file per concept is enough.
- Some related code clean-ups and test improvements.

By setting `--no-write` option user could export concepts collection to standard output instead of to directory.  However, the output was polluted with various messages presented to user, and unsuitable for use.  It was also inconvenient by design.  I doubt anyone was using it, except for in acceptance tests, which have been reworked properly.