### PR TITLE
Parse replaced concepts

### DIFF
--- a/lib/iev/termbase/concept.rb
+++ b/lib/iev/termbase/concept.rb
@@ -32,7 +32,10 @@ module Iev::Termbase
       default_hash = {
         "termid" => id,
         "term" => default_term.terms.first["designation"],
+        "related" => default_term.related_concepts,
       }
+
+      default_hash.compact!
 
       self.inject(default_hash) do |acc, (lang, term)|
         acc.merge!(lang => term.to_hash)

--- a/lib/iev/termbase/supersession_parser.rb
+++ b/lib/iev/termbase/supersession_parser.rb
@@ -1,0 +1,66 @@
+module Iev
+  module Termbase
+    # Parses information from the spreadsheet's REPLACES column.
+    #
+    # @example
+    #   SupersessionParser.new(cell_data_string).supersessions
+    class SupersessionParser
+      using DataConversions
+
+      attr_reader :raw_str, :src_str
+
+      attr_reader :supersessions
+
+      # Regular expression which describes IEV relation, for example
+      # +881-01-23:1983-01+ or +845-03-55:1987+.
+      IEV_SUPERSESSION_RX = %r{
+        \A
+        (?:IEV\s+)? # some are prefixed with IEV, it is unnecessary though
+        (?<ref>\d{3}-\d{2}-\d{2})
+        \s* # some have whitespaces around the separator
+        : # separator
+        \s* # some have whitespaces around the separator
+        (?<version>[-0-9]+)
+        \Z
+      }x.freeze
+
+      def initialize(source_str)
+        @raw_str = source_str.dup.freeze
+        @src_str = raw_str.sanitize.freeze
+        @supersessions = parse
+      end
+
+      private
+
+      def parse
+        return if empty_source?
+
+        if IEV_SUPERSESSION_RX =~ src_str
+          [relation_from_match($~)]
+        else
+          puts "[INCORRECT SUPERSEDED CONCEPT] #{src_str}"
+          nil
+        end
+      end
+
+      def empty_source?
+        /\w/ !~ src_str
+      end
+
+      def relation_from_match(match_data)
+        {
+          "type" => "supersedes",
+          "ref" => iev_ref_from_match(match_data),
+        }
+      end
+
+      def iev_ref_from_match(match_data)
+        {
+          "source" => "IEV",
+          "id" => match_data[:ref],
+          "version" => match_data[:version],
+        }
+      end
+    end
+  end
+end

--- a/lib/iev/termbase/term.rb
+++ b/lib/iev/termbase/term.rb
@@ -30,6 +30,8 @@ module Iev::Termbase
 
     attr_accessor *ATTRIBS
 
+    attr_accessor :superseded_concepts
+
     def initialize(options={})
       initialize_from_options(options)
       # @examples = []
@@ -243,6 +245,12 @@ module Iev::Termbase
         value = ""
       end
       @review_decision = value
+    end
+
+    def related_concepts
+      # TODO someday other relation types too
+      arr = [superseded_concepts].flatten.compact
+      arr.empty? ? nil : arr
     end
   end
 

--- a/lib/iev/termbase/term_builder.rb
+++ b/lib/iev/termbase/term_builder.rb
@@ -63,6 +63,7 @@ module Iev
           definition: extract_definition_value,
           authoritative_source: extract_authoritative_source,
           language_code: row_lang,
+          superseded_concepts: extract_superseded_concepts,
 
           # @todo: Unsorted Attributes
           #
@@ -356,6 +357,12 @@ module Iev
         source_val = find_value_for("SOURCE")
         return nil if source_val.nil?
         SourceParser.new(source_val).parsed_sources
+      end
+
+      def extract_superseded_concepts
+        replaces_val = find_value_for("REPLACES")
+        return nil if replaces_val.nil?
+        SupersessionParser.new(replaces_val).supersessions
       end
 
       SIMG_PATH_REGEX = "<simg .*\\/\\$file\\/([\\d\\-\\w\.]+)>"

--- a/spec/iev/termbase/supersession_parser_spec.rb
+++ b/spec/iev/termbase/supersession_parser_spec.rb
@@ -1,0 +1,83 @@
+RSpec.describe Iev::Termbase::SupersessionParser do
+  # Parses :string metadata or example description.
+  subject do
+    example = RSpec.current_example
+    attributes_str = example.metadata[:string] || example.description
+    described_class.new(attributes_str)
+  end
+
+  example "731-03-24:1991-10-01" do
+    expect(subject.supersessions).to eq([
+      {
+        "type" => "supersedes",
+        "ref" => {
+          "source" => "IEV",
+          "id" => "731-03-24",
+          "version" => "1991-10-01",
+        },
+      }
+    ])
+  end
+
+  example "731-03-24:1991-10" do
+    expect(subject.supersessions).to eq([
+      {
+        "type" => "supersedes",
+        "ref" => {
+          "source" => "IEV",
+          "id" => "731-03-24",
+          "version" => "1991-10",
+        },
+      }
+    ])
+  end
+
+  example "731-03-24:1991" do
+    expect(subject.supersessions).to eq([
+      {
+        "type" => "supersedes",
+        "ref" => {
+          "source" => "IEV",
+          "id" => "731-03-24",
+          "version" => "1991",
+        },
+      }
+    ])
+  end
+
+  example "optional IEV prefix", string: "IEV 731-03-24:1991" do
+    expect(subject.supersessions).to eq([
+      {
+        "type" => "supersedes",
+        "ref" => {
+          "source" => "IEV",
+          "id" => "731-03-24",
+          "version" => "1991",
+        },
+      }
+    ])
+  end
+
+  example "spaces around colon", string: "731-03-24 : 1991" do
+    expect(subject.supersessions).to eq([
+      {
+        "type" => "supersedes",
+        "ref" => {
+          "source" => "IEV",
+          "id" => "731-03-24",
+          "version" => "1991",
+        },
+      }
+    ])
+  end
+
+  example "empty entry", string: " " do
+    expect(subject.supersessions).to be(nil)
+  end
+
+  example "unparsable entry", string: "NOT IEV 731-03:1991" do
+    silence_output_streams do
+      expect(subject.supersessions).to be(nil)
+    end
+  end
+end


### PR DESCRIPTION
Adds proper support for REPLACES column. Fixes #34.

Column data is interpreted as relations between concepts and serialized in YAMLs likewise. There are a few more details to agree on (see discussion in #34), therefore I'm not merging this one in yet. Apart from that, it's ready.