### PR TITLE
Cache Relaton cache in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Cache Relaton DB
+        uses: actions/cache@v2
+        with:
+          path: db
+          key: relaton-test-xlsx2yaml
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6
@@ -68,6 +74,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Cache Relaton DB
+        uses: actions/cache@v2
+        with:
+          path: db
+          key: relaton-test-db2yaml
 
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Persist Relaton database between test runs in GitHub Actions. This should greatly reduce the number of network requests, and consequently mitigate the problem with frequent timeouts. Fixes #102 (hopefully).