### PR TITLE
Delete "release" field from output YAMLs

### DIFF
--- a/lib/iev/termbase/term.rb
+++ b/lib/iev/termbase/term.rb
@@ -26,7 +26,6 @@ module Iev::Termbase
     review_decision_date
     review_decision_event
     review_decision_notes
-    release
     )
 
     attr_accessor *ATTRIBS
@@ -245,11 +244,6 @@ module Iev::Termbase
       end
       @review_decision = value
     end
-
-    def retired?
-      release >= 0
-    end
-
   end
 
 end

--- a/lib/iev/termbase/term_builder.rb
+++ b/lib/iev/termbase/term_builder.rb
@@ -46,7 +46,6 @@ module Iev
           entry_status: find_value_for("STATUS"),
           classification: find_value_for("SYNONYM1STATUS"),
           date_accepted: flesh_date(find_value_for("PUBLICATIONDATE")),
-          release: find_value_for("REPLACES"),
           date_amended: flesh_date(find_value_for("PUBLICATIONDATE")),
           review_date: flesh_date(find_value_for("PUBLICATIONDATE")),
           review_decision_date: flesh_date(find_value_for("PUBLICATIONDATE")),

--- a/spec/acceptance/db2yaml_spec.rb
+++ b/spec/acceptance/db2yaml_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe "IEV Termbase" do
         expect(concept1).to include("term: function")
         expect(concept1).to include("deu:")
         expect(concept1).to include("designation: function")
-        expect(concept1).to include("release: 103-01-01:2009-12")
 
         expect(concept2).to include("termid: 103-01-02")
         expect(concept2).to include("term: functional")

--- a/spec/acceptance/xlsx2yaml_spec.rb
+++ b/spec/acceptance/xlsx2yaml_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe "IEV Termbase" do
         expect(concept1).to include("term: function")
         expect(concept1).to include("deu:")
         expect(concept1).to include("designation: function")
-        expect(concept1).to include("release: 103-01-01:2009-12")
 
         expect(concept2).to include("termid: 103-01-02")
         expect(concept2).to include("term: functional")


### PR DESCRIPTION
There is an odd "release" field in generated YAMLs, probably some leftover.  It is being deleted now.

Regarding REPLACES column, it's going to be imported and represented a different way (see #34).