### PR TITLE
Debug term attributes

### DIFF
--- a/lib/iev/termbase/cli/command.rb
+++ b/lib/iev/termbase/cli/command.rb
@@ -48,6 +48,12 @@ module Iev::Termbase
         aliases: :o,
         default: File.join(Dir.pwd, "concepts.sqlite3"),
         methods: :xlsx2db
+
+      shared_option :debug_term_attributes,
+        desc: "Prints some debug messages on term attributes",
+        type: :boolean,
+        default: false,
+        methods: %i[xlsx2yaml db2yaml]
     end
   end
 end

--- a/lib/iev/termbase/cli/command_helper.rb
+++ b/lib/iev/termbase/cli/command_helper.rb
@@ -35,7 +35,7 @@ module Iev::Termbase
       # Assigns some global variables accordingly, so these settings are
       # available throughout the program.
       def handle_generic_options(options)
-        # TODO These options are yet to be defined.
+        $TERMBASE_DEBUG_TERM_ATTRIBUTES = options[:debug_term_attributes]
       end
     end
   end


### PR DESCRIPTION
- Add a brand new CLI option `--debug-term-attributes`.
- Print term attribute entries which have some extra stuff and couldn't be fully parsed.