### PR TITLE
Support partial exports

### DIFF
--- a/lib/iev/termbase/cli/command.rb
+++ b/lib/iev/termbase/cli/command.rb
@@ -39,6 +39,12 @@ module Iev::Termbase
         [*methods].each { |m| option name, for: m, **kwargs }
       end
 
+      shared_option :only_concepts,
+        desc: "Only process concepts with IEVREF matching this argument, " +
+          "'%' and '_' wildcards are supported and have meaning as in SQL " +
+          "LIKE operator",
+        methods: %i[xlsx2yaml db2yaml]
+
       shared_option :output,
         desc: "Output directory",
         aliases: :o,

--- a/lib/iev/termbase/cli/command.rb
+++ b/lib/iev/termbase/cli/command.rb
@@ -8,7 +8,8 @@ module Iev::Termbase
         handle_generic_options(options)
         db = Sequel.sqlite
         DbWriter.new(db).import_spreadsheet(file)
-        collection = ConceptCollection.build_from_dataset(db[:concepts])
+        ds = filter_dataset(db, options)
+        collection = ConceptCollection.build_from_dataset(ds)
         save_collection_to_files(collection, options[:output])
       end
 
@@ -26,7 +27,8 @@ module Iev::Termbase
       def db2yaml(dbfile)
         handle_generic_options(options)
         db = Sequel.sqlite(dbfile)
-        collection = ConceptCollection.build_from_dataset(db[:concepts])
+        ds = filter_dataset(db, options)
+        collection = ConceptCollection.build_from_dataset(ds)
         save_collection_to_files(collection, options[:output])
       end
 

--- a/lib/iev/termbase/cli/command.rb
+++ b/lib/iev/termbase/cli/command.rb
@@ -45,6 +45,12 @@ module Iev::Termbase
           "LIKE operator",
         methods: %i[xlsx2yaml db2yaml]
 
+      shared_option :only_languages,
+        desc: "Only export these languages, skip concepts which aren't " +
+          "translated to any of them (comma-separated list, language " +
+          "codes must be as in spreadsheet)",
+        methods: %i[xlsx2yaml db2yaml]
+
       shared_option :output,
         desc: "Output directory",
         aliases: :o,

--- a/lib/iev/termbase/cli/command_helper.rb
+++ b/lib/iev/termbase/cli/command_helper.rb
@@ -40,6 +40,11 @@ module Iev::Termbase
 
       def filter_dataset(db, options)
         query = db[:concepts]
+
+        if options[:only_concepts]
+          query = query.where(Sequel.ilike(:ievref, options[:only_concepts]))
+        end
+
         query
       end
     end

--- a/lib/iev/termbase/cli/command_helper.rb
+++ b/lib/iev/termbase/cli/command_helper.rb
@@ -37,6 +37,11 @@ module Iev::Termbase
       def handle_generic_options(options)
         $TERMBASE_DEBUG_TERM_ATTRIBUTES = options[:debug_term_attributes]
       end
+
+      def filter_dataset(db, options)
+        query = db[:concepts]
+        query
+      end
     end
   end
 end

--- a/lib/iev/termbase/cli/command_helper.rb
+++ b/lib/iev/termbase/cli/command_helper.rb
@@ -45,6 +45,10 @@ module Iev::Termbase
           query = query.where(Sequel.ilike(:ievref, options[:only_concepts]))
         end
 
+        if options[:only_languages]
+          query = query.where(language: options[:only_languages].split(","))
+        end
+
         query
       end
     end


### PR DESCRIPTION
Add `--only-concepts` and `--only-languages` CLI options so that partial exports (of given subset of concepts or of given languages) are now possible.