### PR TITLE
Rename two modules

### DIFF
--- a/exe/iev-termbase
+++ b/exe/iev-termbase
@@ -18,4 +18,4 @@ end
 require "iev"
 require "iev/termbase"
 
-Iev::Termbase::Cli.start(ARGV)
+IEV::Termbase::Cli.start(ARGV)

--- a/exe/iev-termbase
+++ b/exe/iev-termbase
@@ -18,4 +18,4 @@ end
 require "iev"
 require "iev/termbase"
 
-IEV::Termbase::Cli.start(ARGV)
+IEV::Termbase::CLI.start(ARGV)

--- a/iev-termbase.gemspec
+++ b/iev-termbase.gemspec
@@ -4,7 +4,7 @@ require "iev/termbase/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "iev-termbase"
-  spec.version       = Iev::Termbase::VERSION
+  spec.version       = IEV::Termbase::VERSION
   spec.authors       = ["Ribose"]
   spec.email         = ["open.source@ribose.com"]
 

--- a/lib/iev.rb
+++ b/lib/iev.rb
@@ -10,7 +10,7 @@ require "zeitwerk"
 loader = Zeitwerk::Loader.for_gem
 loader.setup
 
-module Iev
+module IEV
   def self.root_path
     Pathname.new(File.dirname(__dir__))
   end

--- a/lib/iev.rb
+++ b/lib/iev.rb
@@ -8,6 +8,10 @@ require "yaml"
 require "zeitwerk"
 
 loader = Zeitwerk::Loader.for_gem
+loader.inflector.inflect(
+  "cli" => "CLI",
+  "iev" => "IEV",
+)
 loader.setup
 
 module IEV

--- a/lib/iev/termbase.rb
+++ b/lib/iev/termbase.rb
@@ -1,4 +1,4 @@
-module Iev
+module IEV
   module Termbase
     class Error < StandardError; end
     # Your code goes here...

--- a/lib/iev/termbase/cli.rb
+++ b/lib/iev/termbase/cli.rb
@@ -1,8 +1,8 @@
-module Iev
+module IEV
   module Termbase
     module Cli
       def self.start(arguments)
-        Iev::Termbase::Cli::Command.start(arguments)
+        IEV::Termbase::Cli::Command.start(arguments)
       end
     end
   end

--- a/lib/iev/termbase/cli.rb
+++ b/lib/iev/termbase/cli.rb
@@ -1,8 +1,8 @@
 module IEV
   module Termbase
-    module Cli
+    module CLI
       def self.start(arguments)
-        IEV::Termbase::Cli::Command.start(arguments)
+        IEV::Termbase::CLI::Command.start(arguments)
       end
     end
   end

--- a/lib/iev/termbase/cli/command.rb
+++ b/lib/iev/termbase/cli/command.rb
@@ -1,4 +1,4 @@
-module Iev::Termbase
+module IEV::Termbase
   module Cli
     class Command < Thor
       include CommandHelper

--- a/lib/iev/termbase/cli/command.rb
+++ b/lib/iev/termbase/cli/command.rb
@@ -1,5 +1,5 @@
 module IEV::Termbase
-  module Cli
+  module CLI
     class Command < Thor
       include CommandHelper
 

--- a/lib/iev/termbase/cli/command_helper.rb
+++ b/lib/iev/termbase/cli/command_helper.rb
@@ -1,4 +1,4 @@
-module Iev::Termbase
+module IEV::Termbase
   module Cli
     module CommandHelper
 

--- a/lib/iev/termbase/cli/command_helper.rb
+++ b/lib/iev/termbase/cli/command_helper.rb
@@ -1,5 +1,5 @@
 module IEV::Termbase
-  module Cli
+  module CLI
     module CommandHelper
 
       protected

--- a/lib/iev/termbase/concept.rb
+++ b/lib/iev/termbase/concept.rb
@@ -1,4 +1,4 @@
-module Iev::Termbase
+module IEV::Termbase
   class Concept < Hash
     attr_accessor :id
     attr_accessor :terms

--- a/lib/iev/termbase/concept_collection.rb
+++ b/lib/iev/termbase/concept_collection.rb
@@ -1,4 +1,4 @@
-module Iev::Termbase
+module IEV::Termbase
   class ConceptCollection < Hash
 
     def add_term(term)

--- a/lib/iev/termbase/data_conversions.rb
+++ b/lib/iev/termbase/data_conversions.rb
@@ -1,4 +1,4 @@
-module Iev
+module IEV
   module Termbase
     module DataConversions
       refine String do
@@ -27,7 +27,7 @@ module Iev
         end
 
         def to_three_char_code
-          Iev::Termbase::Iso639Code.three_char_code(self).first
+          IEV::Termbase::Iso639Code.three_char_code(self).first
         end
       end
     end

--- a/lib/iev/termbase/db_writer.rb
+++ b/lib/iev/termbase/db_writer.rb
@@ -1,4 +1,4 @@
-module Iev
+module IEV
   module Termbase
     class DbWriter
       using DataConversions

--- a/lib/iev/termbase/iso_639_code.rb
+++ b/lib/iev/termbase/iso_639_code.rb
@@ -1,4 +1,4 @@
-module Iev
+module IEV
   module Termbase
     class Iso639Code
       COUNTRY_CODES = YAML.load(IO.read(File.join(__dir__, "iso_639_2.yaml")))

--- a/lib/iev/termbase/nested_term_builder.rb
+++ b/lib/iev/termbase/nested_term_builder.rb
@@ -1,4 +1,4 @@
-module Iev
+module IEV
   module Termbase
     class NestedTermBuilder
       def initialize(options = {})

--- a/lib/iev/termbase/relaton_db.rb
+++ b/lib/iev/termbase/relaton_db.rb
@@ -1,6 +1,6 @@
 require "singleton"
 
-module Iev
+module IEV
   module Termbase
     # Relaton cach singleton.
     class RelatonDb

--- a/lib/iev/termbase/source_parser.rb
+++ b/lib/iev/termbase/source_parser.rb
@@ -1,4 +1,4 @@
-module Iev
+module IEV
   module Termbase
     # Parses information from the spreadsheet's SOURCE column.
     #
@@ -287,7 +287,7 @@ module Iev
 
         # pp h
 
-        item = ::Iev::Termbase::RelatonDb.instance.fetch(source_ref)
+        item = ::IEV::Termbase::RelatonDb.instance.fetch(source_ref)
 
         src = {}
 

--- a/lib/iev/termbase/supersession_parser.rb
+++ b/lib/iev/termbase/supersession_parser.rb
@@ -1,4 +1,4 @@
-module Iev
+module IEV
   module Termbase
     # Parses information from the spreadsheet's REPLACES column.
     #

--- a/lib/iev/termbase/term.rb
+++ b/lib/iev/termbase/term.rb
@@ -1,4 +1,4 @@
-module Iev::Termbase
+module IEV::Termbase
   class Term
     ATTRIBS = %i(
     id

--- a/lib/iev/termbase/term_attrs_parser.rb
+++ b/lib/iev/termbase/term_attrs_parser.rb
@@ -1,4 +1,4 @@
-module Iev
+module IEV
   module Termbase
     # Parses information from the spreadsheet's TERMATTRIBUTE column and alike.
     #

--- a/lib/iev/termbase/term_builder.rb
+++ b/lib/iev/termbase/term_builder.rb
@@ -1,6 +1,6 @@
 require "pp"
 
-module Iev
+module IEV
   module Termbase
     class TermBuilder
       using DataConversions
@@ -41,7 +41,7 @@ module Iev
 
         print "\rProcessing term #{row_term_id} (#{row_lang})... "
 
-        Iev::Termbase::Term.new(
+        IEV::Termbase::Term.new(
           id: row_term_id,
           entry_status: find_value_for("STATUS"),
           classification: find_value_for("SYNONYM1STATUS"),
@@ -139,7 +139,7 @@ module Iev
 
         term = mathml_to_asciimath(parse_anchor_tag(raw_term))
 
-        Iev::Termbase::NestedTermBuilder.build(
+        IEV::Termbase::NestedTermBuilder.build(
           type: "expression",
           term: term,
           data: find_value_for("TERMATTRIBUTE"),
@@ -155,7 +155,7 @@ module Iev
           designations.split(/<[pbr]+>/).map do |raw_term|
             term = mathml_to_asciimath(parse_anchor_tag(raw_term))
 
-            Iev::Termbase::NestedTermBuilder.build(
+            IEV::Termbase::NestedTermBuilder.build(
               type: "expression",
               term: term,
               data: find_value_for("SYNONYM#{num}ATTRIBUTE"),
@@ -170,7 +170,7 @@ module Iev
       def extract_international_symbol_designation
         term = mathml_to_asciimath(parse_anchor_tag(find_value_for("SYMBOLE")))
 
-        Iev::Termbase::NestedTermBuilder.build(
+        IEV::Termbase::NestedTermBuilder.build(
           type: "symbol",
           international: true,
           term: term,

--- a/lib/iev/termbase/version.rb
+++ b/lib/iev/termbase/version.rb
@@ -1,4 +1,4 @@
-module Iev
+module IEV
   module Termbase
     VERSION = "0.1.13"
   end

--- a/spec/acceptance/db2yaml_spec.rb
+++ b/spec/acceptance/db2yaml_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "IEV Termbase" do
     it "exports YAMLs from given database" do
       Dir.mktmpdir("iev-test") do |dir|
         command = %W(db2yaml #{sample_db} -o #{dir})
-        silence_output_streams { Iev::Termbase::Cli.start(command) }
+        silence_output_streams { IEV::Termbase::Cli.start(command) }
 
         concepts_dir = File.join(dir, "concepts")
         expect(concepts_dir).to satisfy { |p| File.directory? p }

--- a/spec/acceptance/db2yaml_spec.rb
+++ b/spec/acceptance/db2yaml_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "IEV Termbase" do
     it "exports YAMLs from given database" do
       Dir.mktmpdir("iev-test") do |dir|
         command = %W(db2yaml #{sample_db} -o #{dir})
-        silence_output_streams { IEV::Termbase::Cli.start(command) }
+        silence_output_streams { IEV::Termbase::CLI.start(command) }
 
         concepts_dir = File.join(dir, "concepts")
         expect(concepts_dir).to satisfy { |p| File.directory? p }

--- a/spec/acceptance/xlsx2db_spec.rb
+++ b/spec/acceptance/xlsx2db_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "IEV Termbase" do
       Dir.mktmpdir("iev-test") do |dir|
         dbfile = "#{dir}/test.sqlite3"
         command = %W(xlsx2db #{sample_xlsx_file} -o #{dbfile})
-        silence_output_streams { IEV::Termbase::Cli.start(command) }
+        silence_output_streams { IEV::Termbase::CLI.start(command) }
 
         expect(dbfile).to satisfy { |p| File.file? p }
 

--- a/spec/acceptance/xlsx2db_spec.rb
+++ b/spec/acceptance/xlsx2db_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "IEV Termbase" do
       Dir.mktmpdir("iev-test") do |dir|
         dbfile = "#{dir}/test.sqlite3"
         command = %W(xlsx2db #{sample_xlsx_file} -o #{dbfile})
-        silence_output_streams { Iev::Termbase::Cli.start(command) }
+        silence_output_streams { IEV::Termbase::Cli.start(command) }
 
         expect(dbfile).to satisfy { |p| File.file? p }
 

--- a/spec/acceptance/xlsx2yaml_spec.rb
+++ b/spec/acceptance/xlsx2yaml_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "IEV Termbase" do
     it "exports YAMLs from given XLSX document" do
       Dir.mktmpdir("iev-test") do |dir|
         command = %W(xlsx2yaml #{sample_xlsx_file} -o #{dir})
-        silence_output_streams { Iev::Termbase::Cli.start(command) }
+        silence_output_streams { IEV::Termbase::Cli.start(command) }
 
         concepts_dir = File.join(dir, "concepts")
         expect(concepts_dir).to satisfy { |p| File.directory? p }

--- a/spec/acceptance/xlsx2yaml_spec.rb
+++ b/spec/acceptance/xlsx2yaml_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "IEV Termbase" do
     it "exports YAMLs from given XLSX document" do
       Dir.mktmpdir("iev-test") do |dir|
         command = %W(xlsx2yaml #{sample_xlsx_file} -o #{dir})
-        silence_output_streams { IEV::Termbase::Cli.start(command) }
+        silence_output_streams { IEV::Termbase::CLI.start(command) }
 
         concepts_dir = File.join(dir, "concepts")
         expect(concepts_dir).to satisfy { |p| File.directory? p }

--- a/spec/iev/termbase/data_conversions_spec.rb
+++ b/spec/iev/termbase/data_conversions_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe "string conversion refinements" do
-  using Iev::Termbase::DataConversions
+  using IEV::Termbase::DataConversions
 
   describe "#decode_html" do
     it "decodes HTML entities" do

--- a/spec/iev/termbase/db_writer_spec.rb
+++ b/spec/iev/termbase/db_writer_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe Iev::Termbase::DbWriter do
+RSpec.describe IEV::Termbase::DbWriter do
   let(:instance) { described_class.new(db) }
   let(:db) { Sequel.sqlite }
   let(:sample_file) { fixture_path("sample-file.xlsx") }

--- a/spec/iev/termbase/source_parser_spec.rb
+++ b/spec/iev/termbase/source_parser_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe Iev::Termbase::SourceParser do
+RSpec.describe IEV::Termbase::SourceParser do
   subject do
     example = RSpec.current_example
     attributes_str = example.metadata[:string] || example.description

--- a/spec/iev/termbase/supersession_parser_spec.rb
+++ b/spec/iev/termbase/supersession_parser_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Iev::Termbase::SupersessionParser do
+RSpec.describe IEV::Termbase::SupersessionParser do
   # Parses :string metadata or example description.
   subject do
     example = RSpec.current_example

--- a/spec/iev/termbase/term_attrs_parser_spec.rb
+++ b/spec/iev/termbase/term_attrs_parser_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Iev::Termbase::TermAttrsParser do
+RSpec.describe IEV::Termbase::TermAttrsParser do
   # Parses :string metadata or example description.
   subject do
     example = RSpec.current_example

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,8 +8,8 @@ Dir["./spec/support/**/*.rb"].sort.each { |file| require file }
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
-  config.include Iev::ConsoleHelper
-  config.include Iev::FixtureHelper
+  config.include IEV::ConsoleHelper
+  config.include IEV::FixtureHelper
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!

--- a/spec/support/console_helper.rb
+++ b/spec/support/console_helper.rb
@@ -1,4 +1,4 @@
-module Iev
+module IEV
   module ConsoleHelper
     # Executes given block.  Anything written to $stdout or $stderr in that
     # block is captured and returned.

--- a/spec/support/fixture_helper.rb
+++ b/spec/support/fixture_helper.rb
@@ -1,4 +1,4 @@
-module Iev
+module IEV
   module FixtureHelper
     def fixture_path(fixture_name)
       File.expand_path(fixture_name, fixture_root)


### PR DESCRIPTION
Rename modules `Iev` => `IEV` and `Cli` => `CLI` because their lower case style is unconventional and annoying in fact.