### PR TITLE
Support Unicode signs when parsing usage info

### DIFF
--- a/lib/iev/termbase/term_attrs_parser.rb
+++ b/lib/iev/termbase/term_attrs_parser.rb
@@ -92,10 +92,17 @@ module IEV
       end
 
       def extract_usage_info(str)
-        info_rx = /<(.*?)>/
+        info_rx = %r{
+          # regular ASCII less and greater than signs
+          < (?<inner>.*?) >
+          |
+          # ＜ and ＞, i.e. full-width less and greater than signs
+          # which are used instead of ASCII signs in some CJK terms
+          \uFF1C (?<inner>.*?) \uFF1E
+        }x.freeze
 
         remove_from_string(str, info_rx) do |md|
-          @usage_info = md[1].strip
+          @usage_info = md[:inner].strip
         end
       end
 

--- a/spec/iev/termbase/term_attrs_parser_spec.rb
+++ b/spec/iev/termbase/term_attrs_parser_spec.rb
@@ -157,6 +157,15 @@ RSpec.describe IEV::Termbase::TermAttrsParser do
       string: "a whatever" do
       expect(subject.usage_info).to be(nil)
     end
+
+    it "supports full-width signs", string: "a string \uFF1Cinfo\uFF1E" do
+      expect(subject.usage_info).to eq("info")
+    end
+
+    it "disallows mixing regular and full-width signs",
+      string: "a string \uFF1Cinfo>" do
+      expect(subject.usage_info).to be(nil)
+    end
   end
 
   describe "geographical area" do


### PR DESCRIPTION
In CJK languages, full-width sings (`＜` and `＞`) are typically used instead of regular ones (`<` and `>`). This pull request adds support for full-width signs when parsing term attributes so that usage info part may be properly detected.

Refer to: https://unicode-table.com/en/blocks/halfwidth-and-fullwidth-forms/.