### PR TITLE
Consistent and improved CLI output

### DIFF
--- a/lib/iev/termbase/cli/command_helper.rb
+++ b/lib/iev/termbase/cli/command_helper.rb
@@ -10,7 +10,7 @@ module IEV::Termbase
       protected
 
       def save_collection_to_files(collection, output_dir)
-        CLI::UI.progress "Writing concepts to files..."
+        CLI::UI.info "Writing concepts to files..."
         output_dir = Pathname.new(output_dir.to_s)
 
         concept_dir = output_dir.join("concepts")
@@ -24,7 +24,7 @@ module IEV::Termbase
       # Note: Implementation examples here:
       # https://www.rubydoc.info/github/luislavena/sqlite3-ruby/SQLite3/Backup
       def save_db_to_file(src_db, dbfile)
-        CLI::UI.progress "Saving database to a file..."
+        CLI::UI.info "Saving database to a file..."
         src_db.synchronize do |src_conn|
           dest_conn = SQLite3::Database.new(dbfile)
           b = SQLite3::Backup.new(dest_conn, "main", src_conn, "main")
@@ -34,7 +34,7 @@ module IEV::Termbase
       end
 
       def summary
-        CLI::UI.progress "Done!", persistent: true
+        CLI::UI.info "Done!"
       end
 
       def collection_file_path(file, output_dir)

--- a/lib/iev/termbase/cli/command_helper.rb
+++ b/lib/iev/termbase/cli/command_helper.rb
@@ -6,11 +6,12 @@
 module IEV::Termbase
   module CLI
     module CommandHelper
+      include CLI::UI
 
       protected
 
       def save_collection_to_files(collection, output_dir)
-        CLI::UI.info "Writing concepts to files..."
+        info "Writing concepts to files..."
         output_dir = Pathname.new(output_dir.to_s)
 
         concept_dir = output_dir.join("concepts")
@@ -24,7 +25,7 @@ module IEV::Termbase
       # Note: Implementation examples here:
       # https://www.rubydoc.info/github/luislavena/sqlite3-ruby/SQLite3/Backup
       def save_db_to_file(src_db, dbfile)
-        CLI::UI.info "Saving database to a file..."
+        info "Saving database to a file..."
         src_db.synchronize do |src_conn|
           dest_conn = SQLite3::Database.new(dbfile)
           b = SQLite3::Backup.new(dest_conn, "main", src_conn, "main")
@@ -34,7 +35,7 @@ module IEV::Termbase
       end
 
       def summary
-        CLI::UI.info "Done!"
+        info "Done!"
       end
 
       def collection_file_path(file, output_dir)

--- a/lib/iev/termbase/cli/ui.rb
+++ b/lib/iev/termbase/cli/ui.rb
@@ -9,10 +9,23 @@ module IEV
       module UI
         module_function
 
-        def progress(message, persistent: false)
+        # Prints progress message which will be replaced on next call.
+        def progress(message)
           return unless $TERMBASE_PROGRESS
-          print "\r#{" " * 40}\r" # clear line
-          print persistent ? "#{message}\n" : "#{message} "
+          print "#{Helper.clear_progress}#{message} "
+        end
+
+        # Prints generic message.
+        def info(message)
+          print "#{Helper.clear_progress}#{message}\n"
+        end
+
+        module Helper
+          module_function
+
+          def clear_progress
+            $TERMBASE_PROGRESS ? "\r#{" " * 40}\r" : ""
+          end
         end
       end
     end

--- a/lib/iev/termbase/cli/ui.rb
+++ b/lib/iev/termbase/cli/ui.rb
@@ -28,6 +28,12 @@ module IEV
           print "#{Helper.clear_progress}#{message}\n"
         end
 
+        # Sets an UI tag which will be prepended to messages printed with
+        # #debug and #warn.
+        def set_ui_tag(str)
+          Thread.current[:iev_ui_tag] = str
+        end
+
         module Helper
           module_function
 
@@ -37,9 +43,12 @@ module IEV
 
           def cli_out(_level, *args)
             message = args.map(&:to_s).join(" ").chomp
+            ui_tag = Thread.current[:iev_ui_tag]
 
             print [
               clear_progress,
+              ui_tag,
+              ui_tag && ": ",
               message,
               "\n",
             ].join

--- a/lib/iev/termbase/cli/ui.rb
+++ b/lib/iev/termbase/cli/ui.rb
@@ -6,6 +6,10 @@
 module IEV
   module Termbase
     module CLI
+      # @todo
+      #   Make it thread-safe.  Currently, calling UI methods from different
+      #   threads may result with mangled output.  At first glance it seems like
+      #   something is wrong with carriage returns, but more research is needed.
       module UI
         module_function
 

--- a/lib/iev/termbase/cli/ui.rb
+++ b/lib/iev/termbase/cli/ui.rb
@@ -9,6 +9,14 @@ module IEV
       module UI
         module_function
 
+        def debug(*args)
+          Helper.cli_out(:debug, *args)
+        end
+
+        def warn(*args)
+          Helper.cli_out(:warn, *args)
+        end
+
         # Prints progress message which will be replaced on next call.
         def progress(message)
           return unless $TERMBASE_PROGRESS
@@ -25,6 +33,16 @@ module IEV
 
           def clear_progress
             $TERMBASE_PROGRESS ? "\r#{" " * 40}\r" : ""
+          end
+
+          def cli_out(_level, *args)
+            message = args.map(&:to_s).join(" ").chomp
+
+            print [
+              clear_progress,
+              message,
+              "\n",
+            ].join
           end
         end
       end

--- a/lib/iev/termbase/concept.rb
+++ b/lib/iev/termbase/concept.rb
@@ -5,6 +5,8 @@
 
 module IEV::Termbase
   class Concept < Hash
+    include CLI::UI
+
     attr_accessor :id
     attr_accessor :terms
     DEFAULT_LANGUAGE = "eng"
@@ -28,7 +30,7 @@ module IEV::Termbase
       if self[DEFAULT_LANGUAGE]
         self[DEFAULT_LANGUAGE]
       else
-        CLI::UI.warn "[tc211-termbase] term (lang: #{keys.first}, ID: #{id}) is missing a corresponding English term, probably needs updating."
+        warn "[tc211-termbase] term (lang: #{keys.first}, ID: #{id}) is missing a corresponding English term, probably needs updating."
         self[keys.first]
       end
     end

--- a/lib/iev/termbase/concept.rb
+++ b/lib/iev/termbase/concept.rb
@@ -31,7 +31,7 @@ module IEV::Termbase
         self[DEFAULT_LANGUAGE]
       else
         set_ui_tag id
-        warn "[tc211-termbase] term (lang: #{keys.first}, ID: #{id}) is missing a corresponding English term, probably needs updating."
+        warn "Concept is missing an English term and probably needs updating."
         self[keys.first]
       end
     end

--- a/lib/iev/termbase/concept.rb
+++ b/lib/iev/termbase/concept.rb
@@ -30,6 +30,7 @@ module IEV::Termbase
       if self[DEFAULT_LANGUAGE]
         self[DEFAULT_LANGUAGE]
       else
+        set_ui_tag id
         warn "[tc211-termbase] term (lang: #{keys.first}, ID: #{id}) is missing a corresponding English term, probably needs updating."
         self[keys.first]
       end

--- a/lib/iev/termbase/concept.rb
+++ b/lib/iev/termbase/concept.rb
@@ -28,7 +28,7 @@ module IEV::Termbase
       if self[DEFAULT_LANGUAGE]
         self[DEFAULT_LANGUAGE]
       else
-        puts "[tc211-termbase] term (lang: #{keys.first}, ID: #{id}) is missing a corresponding English term, probably needs updating."
+        CLI::UI.warn "[tc211-termbase] term (lang: #{keys.first}, ID: #{id}) is missing a corresponding English term, probably needs updating."
         self[keys.first]
       end
     end

--- a/lib/iev/termbase/concept.rb
+++ b/lib/iev/termbase/concept.rb
@@ -27,11 +27,8 @@ module IEV::Termbase
     end
 
     def default_term
-      if self[DEFAULT_LANGUAGE]
-        self[DEFAULT_LANGUAGE]
-      else
-        set_ui_tag id
-        warn "Concept is missing an English term and probably needs updating."
+      self[DEFAULT_LANGUAGE] or begin
+        warn_about_missing_default_term
         self[keys.first]
       end
     end
@@ -56,5 +53,14 @@ module IEV::Termbase
       end
     end
 
+    private
+
+    def warn_about_missing_default_term
+      unless @already_warned_about_default_term
+        @already_warned_about_default_term = true
+        set_ui_tag id
+        warn "Concept is missing an English term and probably needs updating."
+      end
+    end
   end
 end

--- a/lib/iev/termbase/db_writer.rb
+++ b/lib/iev/termbase/db_writer.rb
@@ -35,7 +35,7 @@ module IEV
       private
 
       def open_workbook(file)
-        puts "Opening spreadsheet..."
+        CLI::UI.info "Opening spreadsheet..."
         Creek::Book.new(file)
       end
 
@@ -72,7 +72,7 @@ module IEV
       def insert_data(data)
         db[:concepts].insert(data)
       rescue Sequel::UniqueConstraintViolation
-        puts "SKIPPING, duplicated (TERMID, LANGUAGE) pair"
+        CLI::UI.warn "SKIPPING, duplicated (TERMID, LANGUAGE) pair"
       end
     end
   end

--- a/lib/iev/termbase/db_writer.rb
+++ b/lib/iev/termbase/db_writer.rb
@@ -67,6 +67,7 @@ module IEV
       def display_progress(data)
         ievref = data[:IEVREF]
         lang = data[:LANGUAGE].to_three_char_code
+        set_ui_tag "#{ievref} (#{lang})"
         progress "Importing term #{ievref} (#{lang})..."
       end
 

--- a/lib/iev/termbase/db_writer.rb
+++ b/lib/iev/termbase/db_writer.rb
@@ -6,6 +6,7 @@
 module IEV
   module Termbase
     class DbWriter
+      include CLI::UI
       using DataConversions
 
       attr_reader :db
@@ -35,7 +36,7 @@ module IEV
       private
 
       def open_workbook(file)
-        CLI::UI.info "Opening spreadsheet..."
+        info "Opening spreadsheet..."
         Creek::Book.new(file)
       end
 
@@ -66,13 +67,13 @@ module IEV
       def display_progress(data)
         ievref = data[:IEVREF]
         lang = data[:LANGUAGE].to_three_char_code
-        CLI::UI.progress "Importing term #{ievref} (#{lang})..."
+        progress "Importing term #{ievref} (#{lang})..."
       end
 
       def insert_data(data)
         db[:concepts].insert(data)
       rescue Sequel::UniqueConstraintViolation
-        CLI::UI.warn "SKIPPING, duplicated (TERMID, LANGUAGE) pair"
+        warn "SKIPPING, duplicated (TERMID, LANGUAGE) pair"
       end
     end
   end

--- a/lib/iev/termbase/db_writer.rb
+++ b/lib/iev/termbase/db_writer.rb
@@ -74,7 +74,7 @@ module IEV
       def insert_data(data)
         db[:concepts].insert(data)
       rescue Sequel::UniqueConstraintViolation
-        warn "SKIPPING, duplicated (TERMID, LANGUAGE) pair"
+        warn "Duplicated (TERMID, LANGUAGE) pair, skipping"
       end
     end
   end

--- a/lib/iev/termbase/source_parser.rb
+++ b/lib/iev/termbase/source_parser.rb
@@ -106,7 +106,7 @@ module IEV
           /Constitution de l’Union internationale des télécommunications (UIT)/
           "International Telecommunication Union (ITU) Constitution (Ed. 2015)"
         else
-          warn "[FAILED TO PARSE SOURCE] #{str}"
+          warn "Failed to parse source: '#{str}'"
           str
         end
 

--- a/lib/iev/termbase/source_parser.rb
+++ b/lib/iev/termbase/source_parser.rb
@@ -10,6 +10,7 @@ module IEV
     # @example
     #   SourceParser.new(cell_data_string).parsed_sources
     class SourceParser
+      include CLI::UI
       using DataConversions
 
       attr_reader :src_split, :parsed_sources, :raw_str, :src_str
@@ -105,7 +106,7 @@ module IEV
           /Constitution de l’Union internationale des télécommunications (UIT)/
           "International Telecommunication Union (ITU) Constitution (Ed. 2015)"
         else
-          CLI::UI.warn "[FAILED TO PARSE SOURCE] #{str}"
+          warn "[FAILED TO PARSE SOURCE] #{str}"
           str
         end
 

--- a/lib/iev/termbase/source_parser.rb
+++ b/lib/iev/termbase/source_parser.rb
@@ -105,7 +105,7 @@ module IEV
           /Constitution de l’Union internationale des télécommunications (UIT)/
           "International Telecommunication Union (ITU) Constitution (Ed. 2015)"
         else
-          puts "[FAILED TO PARSE SOURCE] #{str}"
+          CLI::UI.warn "[FAILED TO PARSE SOURCE] #{str}"
           str
         end
 

--- a/lib/iev/termbase/supersession_parser.rb
+++ b/lib/iev/termbase/supersession_parser.rb
@@ -44,7 +44,7 @@ module IEV
         if IEV_SUPERSESSION_RX =~ src_str
           [relation_from_match($~)]
         else
-          warn "[INCORRECT SUPERSEDED CONCEPT] #{src_str}"
+          warn "Incorrect supersession: '#{src_str}'"
           nil
         end
       end

--- a/lib/iev/termbase/supersession_parser.rb
+++ b/lib/iev/termbase/supersession_parser.rb
@@ -10,6 +10,7 @@ module IEV
     # @example
     #   SupersessionParser.new(cell_data_string).supersessions
     class SupersessionParser
+      include CLI::UI
       using DataConversions
 
       attr_reader :raw_str, :src_str
@@ -43,7 +44,7 @@ module IEV
         if IEV_SUPERSESSION_RX =~ src_str
           [relation_from_match($~)]
         else
-          CLI::UI.warn "[INCORRECT SUPERSEDED CONCEPT] #{src_str}"
+          warn "[INCORRECT SUPERSEDED CONCEPT] #{src_str}"
           nil
         end
       end

--- a/lib/iev/termbase/supersession_parser.rb
+++ b/lib/iev/termbase/supersession_parser.rb
@@ -43,7 +43,7 @@ module IEV
         if IEV_SUPERSESSION_RX =~ src_str
           [relation_from_match($~)]
         else
-          puts "[INCORRECT SUPERSEDED CONCEPT] #{src_str}"
+          CLI::UI.warn "[INCORRECT SUPERSEDED CONCEPT] #{src_str}"
           nil
         end
       end

--- a/lib/iev/termbase/term_attrs_parser.rb
+++ b/lib/iev/termbase/term_attrs_parser.rb
@@ -13,6 +13,7 @@ module IEV
     #   parser.plurality # returns grammatical plurality
     #   parser.part_of_speech # returns part of speech
     class TermAttrsParser
+      include CLI::UI
       using DataConversions
 
       attr_reader :raw_str, :src_str
@@ -137,7 +138,7 @@ module IEV
 
       def print_debug(remaining_str)
         if /\p{Word}/ =~ remaining_str
-          CLI::UI.debug "Term attributes could not be parsed completely: " +
+          debug "Term attributes could not be parsed completely: " +
             "'#{src_str}'"
         end
       end

--- a/lib/iev/termbase/term_attrs_parser.rb
+++ b/lib/iev/termbase/term_attrs_parser.rb
@@ -137,7 +137,7 @@ module IEV
 
       def print_debug(remaining_str)
         if /\p{Word}/ =~ remaining_str
-          puts "Term attributes could not be parsed completely: " +
+          CLI::UI.debug "Term attributes could not be parsed completely: " +
             "'#{src_str}'"
         end
       end

--- a/lib/iev/termbase/term_builder.rb
+++ b/lib/iev/termbase/term_builder.rb
@@ -45,6 +45,7 @@ module IEV
         row_term_id = find_value_for("IEVREF")
         row_lang = find_value_for("LANGUAGE").to_three_char_code
 
+        set_ui_tag "#{row_term_id} (#{row_lang})"
         progress "Processing term #{row_term_id} (#{row_lang})..."
 
         IEV::Termbase::Term.new(

--- a/lib/iev/termbase/term_builder.rb
+++ b/lib/iev/termbase/term_builder.rb
@@ -8,6 +8,7 @@ require "pp"
 module IEV
   module Termbase
     class TermBuilder
+      include CLI::UI
       using DataConversions
 
       NOTE_REGEX_1 = /Note[\s ]*\d+[\s ]to entry:\s+|Note[\s ]*\d+?[\s ]à l['’]article:[\s ]*|<NOTE\/?>?[\s ]*\d?[\s ]+.*?–\s+|NOTE[\s ]+-[\s ]+/i
@@ -44,7 +45,7 @@ module IEV
         row_term_id = find_value_for("IEVREF")
         row_lang = find_value_for("LANGUAGE").to_three_char_code
 
-        CLI::UI.progress "Processing term #{row_term_id} (#{row_lang})..."
+        progress "Processing term #{row_term_id} (#{row_lang})..."
 
         IEV::Termbase::Term.new(
           id: row_term_id,


### PR DESCRIPTION
This pull request improves CLI output in many aspects, most notably:

- The `CLI::UI` module now features `#debug`, `#info` and `#warn` methods are introduced. They should be used instead of `Kernel#puts`. For now there is no difference between `#debug` and `#warn`, but it will change in future.
- These methods print messages in a consistent format, providing better readability both in development and in CI.
- UI tags (`CLI::UI#set_ui_tag`) are introduced so that every debug and warning message can be easily and reliably prepended with concept ID and language.
- Relaton warnings are captured and printed in a way that is consistent with other logged messages.

The improved UI was also meant to be thread-safe (as #139 prerequisite), but is not yet. Calling it from different threads may result with mangled output.