### PR TITLE
Improve performance of Iso639Code class

### DIFF
--- a/lib/iev/termbase/iso_639_code.rb
+++ b/lib/iev/termbase/iso_639_code.rb
@@ -5,8 +5,10 @@
 
 module IEV
   module Termbase
+    # @todo This needs to be rewritten.
     class Iso639Code
       COUNTRY_CODES = YAML.load(IO.read(File.join(__dir__, "iso_639_2.yaml")))
+      THREE_CHAR_MEMO = {}
 
       def initialize(two_char_code)
         @code = case two_char_code.length
@@ -31,7 +33,8 @@ module IEV
       end
 
       def self.three_char_code(two_char_code, code_type="terminology")
-        new(two_char_code).find(code_type)
+        memo_index = [two_char_code, code_type]
+        THREE_CHAR_MEMO[memo_index] ||= new(two_char_code).find(code_type)
       end
 
       private


### PR DESCRIPTION
It was slow as hell and had significant impact on processing time. Memoizing return values helped to eliminate repetitive computing.

That said, language codes mapping should rather be a hash. This class needs to be rewritten from scratch.

![Zrzut ekranu 2021-03-13 o 16 37 19](https://user-images.githubusercontent.com/154287/111035798-5716e100-841c-11eb-90ca-574aea999c3f.png)
