### PR TITLE
Improve the guard clause in math parsing

### DIFF
--- a/lib/iev/termbase/term_builder.rb
+++ b/lib/iev/termbase/term_builder.rb
@@ -327,7 +327,7 @@ module IEV
       end
 
       def mathml_to_asciimath(input)
-        return input if input.nil? || input.empty?
+        return input if input.nil? || input.empty? || !input.include?("<")
 
         unless input.match?(/<math>/)
           return html_to_asciimath(input)


### PR DESCRIPTION
This simple test for `<` character, which is always present in MathML and HTML mathematical formulas, improves performance of concepts generation (`ConceptsCollection::build_from_dataset`) two-fold.

Fixes #144.