### PR TITLE
More CLI options for debugging

### DIFF
--- a/lib/iev/termbase/cli/command.rb
+++ b/lib/iev/termbase/cli/command.rb
@@ -83,6 +83,18 @@ module IEV::Termbase
         default: false,
         methods: %i[xlsx2yaml db2yaml]
 
+      shared_option :debug_sources,
+        desc: "...",
+        type: :boolean,
+        default: false,
+        methods: %i[xlsx2yaml db2yaml]
+
+      shared_option :debug_relaton,
+        desc: "...",
+        type: :boolean,
+        default: false,
+        methods: %i[xlsx2yaml db2yaml]
+
       shared_option :profile,
         desc: "Generates profiler reports for this program, requires ruby-prof",
         type: :boolean,

--- a/lib/iev/termbase/cli/command_helper.rb
+++ b/lib/iev/termbase/cli/command_helper.rb
@@ -50,7 +50,10 @@ module IEV::Termbase
       def handle_generic_options(options)
         $TERMBASE_PROFILE = options[:profile]
         $TERMBASE_PROGRESS = options.fetch(:progress, !ENV["CI"])
-        $TERMBASE_DEBUG_TERM_ATTRIBUTES = options[:debug_term_attributes]
+
+        $TERMBASE_DEBUG = options.to_h.
+          select { |k,_| k.to_s.start_with? "debug_" }.
+          transform_keys { |k| k.to_s.sub("debug_", "").to_sym }
       end
 
       def filter_dataset(db, options)

--- a/lib/iev/termbase/cli/ui.rb
+++ b/lib/iev/termbase/cli/ui.rb
@@ -45,9 +45,12 @@ module IEV
             $TERMBASE_PROGRESS ? "\r#{" " * 40}\r" : ""
           end
 
-          def cli_out(_level, *args)
+          def cli_out(level, *args)
+            topic = Symbol === args[0] ? args.shift : nil
             message = args.map(&:to_s).join(" ").chomp
             ui_tag = Thread.current[:iev_ui_tag]
+
+            return unless should_out?(level, topic)
 
             print [
               clear_progress,
@@ -56,6 +59,10 @@ module IEV
               message,
               "\n",
             ].join
+          end
+
+          def should_out?(level, topic)
+            topic.nil? || level == :warn || $TERMBASE_DEBUG[topic]
           end
         end
       end

--- a/lib/iev/termbase/relaton_db.rb
+++ b/lib/iev/termbase/relaton_db.rb
@@ -56,7 +56,7 @@ module IEV
         ensure
           $stdout = original_stdout
           $stderr = original_stderr
-          warn(fake_out.string) if fake_out.pos > 0
+          debug(:relaton, fake_out.string) if fake_out.pos > 0
         end
       end
     end

--- a/lib/iev/termbase/source_parser.rb
+++ b/lib/iev/termbase/source_parser.rb
@@ -106,7 +106,7 @@ module IEV
           /Constitution de l’Union internationale des télécommunications (UIT)/
           "International Telecommunication Union (ITU) Constitution (Ed. 2015)"
         else
-          warn "Failed to parse source: '#{str}'"
+          debug :sources, "Failed to parse source: '#{str}'"
           str
         end
 

--- a/lib/iev/termbase/term_attrs_parser.rb
+++ b/lib/iev/termbase/term_attrs_parser.rb
@@ -144,7 +144,7 @@ module IEV
       end
 
       def debug?
-        $TERMBASE_DEBUG_TERM_ATTRIBUTES
+        $TERMBASE_DEBUG[:term_attributes]
       end
     end
   end

--- a/lib/iev/termbase/term_attrs_parser.rb
+++ b/lib/iev/termbase/term_attrs_parser.rb
@@ -58,7 +58,12 @@ module IEV
         extract_usage_info(curr_str)
         extract_prefix(curr_str)
 
-        print_debug(curr_str) if debug?
+        if /\p{Word}/ =~ curr_str
+          debug(
+            :term_attributes,
+            "Term attributes could not be parsed completely: '#{src_str}'",
+          )
+        end
       end
 
       def extract_gender(str)
@@ -134,17 +139,6 @@ module IEV
         else
           $& # removed substring or nil
         end
-      end
-
-      def print_debug(remaining_str)
-        if /\p{Word}/ =~ remaining_str
-          debug "Term attributes could not be parsed completely: " +
-            "'#{src_str}'"
-        end
-      end
-
-      def debug?
-        $TERMBASE_DEBUG[:term_attributes]
       end
     end
   end


### PR DESCRIPTION
Adds `--debug-sources` and `--debug-relaton` CLI option. Effectively makes output less verbose, as only data integrity warnings are printed when debug options are turned off.