### PR TITLE
More Unicode normalization

### DIFF
--- a/lib/iev/termbase/data_conversions.rb
+++ b/lib/iev/termbase/data_conversions.rb
@@ -22,6 +22,7 @@ module IEV
           gsub!("\uFEFF", "")
           gsub!("\u2011", "-")
           gsub!("\u00a0", " ")
+          gsub!(/[\u2000-\u2006]/, " ")
           strip!
           nil
         end


### PR DESCRIPTION
I'm adding more Unicode normalization. Specifically, characters from u2000 to u2006 are now replaced with regular spaces. At least u2002 occurs in the spreadsheets in 351-41-xx concepts.

I am going to merge it, but pinging @ronaldtse just in case. Here is these characters' meaning: https://www.compart.com/en/unicode/category/Zs.