### PR TITLE
Manual trigger for running CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - master
-
   pull_request:
+  workflow_dispatch:
 
 jobs:
   rspec:


### PR DESCRIPTION
By supporting `workflow_dispatch` event, tests can be launched from GitHub Actions web interface too.