### PR TITLE
Print some message on Relaton initialization

### DIFF
--- a/lib/iev/termbase/relaton_db.rb
+++ b/lib/iev/termbase/relaton_db.rb
@@ -13,6 +13,7 @@ module IEV
       include CLI::UI
 
       def initialize
+        info "Initializing Relaton..."
         @db = Relaton::Db.new "db", nil
       end
 


### PR DESCRIPTION
Relaton initialization itself prints some information to output stream. It's a good idea to precede that with some message so that it is nicely integrated rather than mixed with other debug messages.