### PR TITLE
Print message when Relaton fails to fetch document

### DIFF
--- a/lib/iev/termbase/relaton_db.rb
+++ b/lib/iev/termbase/relaton_db.rb
@@ -20,14 +20,24 @@ module IEV
       # @param code [String] reference
       # @return [RelatonIso::IsoBibliongraphicItem]
       def fetch(code)
+        relaton_item = fetch!(code)
+
+        if relaton_item.nil?
+          debug(:relaton, "Could not fetch authorative source '#{code}'.")
+        end
+
+        relaton_item
+      end
+
+      private
+
+      def fetch!(code)
         retrying_on_failures do
           capture_output_streams do
             @db.fetch code
           end
         end
       end
-
-      private
 
       def retrying_on_failures(attempts: 4)
         curr_attempt = 1


### PR DESCRIPTION
If Relaton returns nil for given document query, that means one of following:

- Relaton does not support given type of document yet (feature request needed)
- There is a bug Relaton (bug report needed)
- It wasn't a document ref (source needs to be fixed or given pattern should be ignored)

In either case, debug message is potentially useful.