### PR TITLE
Clean Source Parser up

### DIFF
--- a/lib/iev/termbase/source_parser.rb
+++ b/lib/iev/termbase/source_parser.rb
@@ -62,30 +62,10 @@ module IEV
       end
 
       def extract_single_source(raw_ref)
-        # source = "ISO/IEC GUIDE 99:2007 1.26"
-        # raw_ref = str.match(/\A[^,\()]+/).to_s
-
-        # puts "[extract_single_source] #{raw_ref}"
-
         relation_type = extract_source_relationship(raw_ref)
-
         clean_ref = normalize_ref_string(raw_ref)
-
         source_ref = extract_source_ref(clean_ref)
-
         clause = extract_source_clause(clean_ref)
-
-        # puts "CLAUSENIL!!! #{raw_ref}" if clause.nil?
-        # puts "SOURCE!!! #{raw_ref}" if source_ref.nil?
-
-        # puts "[RAW] #{raw_ref}"
-        # h = {
-        #   source_ref: source_ref,
-        #   clause: clause,
-        #   relation_type: relation_type
-        # }
-
-        # pp h
 
         {
           "ref" => source_ref,

--- a/lib/iev/termbase/source_parser.rb
+++ b/lib/iev/termbase/source_parser.rb
@@ -87,7 +87,7 @@ module IEV
 
         # pp h
 
-        item = ::IEV::Termbase::RelatonDb.instance.fetch(source_ref)
+        item = RelatonDb.instance.fetch(source_ref)
 
         src = {}
 

--- a/lib/iev/termbase/source_parser.rb
+++ b/lib/iev/termbase/source_parser.rb
@@ -129,67 +129,67 @@ module IEV
           "JCGM VIM"
         # IEC 60050-121, 151-12-05
         when /IEC 60050-(\d+), (\d{2,3}-\d{2,3}-\d{2,3})/
-          "IEC 60050-#{$LAST_MATCH_INFO[1]}"
+          "IEC 60050-#{$1}"
         when /IEC 60050-(\d+):(\d+), (\d{2,3}-\d{2,3}-\d{2,3})/
-          "IEC 60050-#{$LAST_MATCH_INFO[1]}:#{$LAST_MATCH_INFO[2]}"
+          "IEC 60050-#{$1}:#{$2}"
         when /(AIEA|IAEA) (\d+)/
-          "IAEA #{$LAST_MATCH_INFO[2]}"
+          "IAEA #{$2}"
         when /IEC\sIEEE ([\d\:\-]+)/
-          "IEC/IEEE #{$LAST_MATCH_INFO[1]}".sub(/:\Z/, "")
+          "IEC/IEEE #{$1}".sub(/:\Z/, "")
         when /CISPR ([\d\:\-]+)/
-          "IEC CISPR #{$LAST_MATCH_INFO[1]}"
+          "IEC CISPR #{$1}"
         when /RR (\d+)/
           "ITU RR"
         # IEC 50(845)
         when /IEC (\d+)\((\d+)\)/
-          "IEC 600#{$LAST_MATCH_INFO[1]}-#{$LAST_MATCH_INFO[1]}"
+          "IEC 600#{$1}-#{$1}"
         when /(ISO|IEC)[\/\ ](PAS|TR|TS) ([\d\:\-]+)/
-          "#{$LAST_MATCH_INFO[1]}/#{$LAST_MATCH_INFO[2]} #{$LAST_MATCH_INFO[3]}".sub(/:\Z/, "")
+          "#{$1}/#{$2} #{$3}".sub(/:\Z/, "")
         when /ISO\/IEC ([\d\:\-]+)/
-          "ISO/IEC #{$LAST_MATCH_INFO[1]}".sub(/:\Z/, "")
+          "ISO/IEC #{$1}".sub(/:\Z/, "")
         when /ISO\/IEC\/IEEE ([\d\:\-]+)/
-          "ISO/IEC/IEEE #{$LAST_MATCH_INFO[1]}".sub(/:\Z/, "")
+          "ISO/IEC/IEEE #{$1}".sub(/:\Z/, "")
 
         # ISO 140/4
         when /ISO (\d+)\/(\d+)/
-          "ISO #{$LAST_MATCH_INFO[1]}-#{$LAST_MATCH_INFO[2]}"
+          "ISO #{$1}-#{$2}"
         when /Norme ISO (\d+)-(\d+)/
-          "ISO #{$LAST_MATCH_INFO[1]}:#{$LAST_MATCH_INFO[2]}"
+          "ISO #{$1}:#{$2}"
         when /ISO\/IEC Guide ([\d\:\-]+)/i
-          "ISO/IEC Guide #{$LAST_MATCH_INFO[1]}".sub(/:\Z/, "")
+          "ISO/IEC Guide #{$1}".sub(/:\Z/, "")
         when /(ISO|IEC) Guide ([\d\:\-]+)/i
-          "#{$LAST_MATCH_INFO[1]} Guide #{$LAST_MATCH_INFO[2]}".sub(/:\Z/, "")
+          "#{$1} Guide #{$2}".sub(/:\Z/, "")
 
         # ITU-T Recommendation F.791 (11/2015)
         when /ITU-T Recommendation (\w.\d+) \((\d+\/\d+)\)/i
-          "ITU-T Recommendation #{$LAST_MATCH_INFO[1]} (#{$LAST_MATCH_INFO[2]})"
+          "ITU-T Recommendation #{$1} (#{$2})"
 
         # ITU-T Recommendation F.791:2015
         when /ITU-T Recommendation (\w.\d+):(\d+)/i
-          "ITU-T Recommendation #{$LAST_MATCH_INFO[1]} (#{$LAST_MATCH_INFO[2]})"
+          "ITU-T Recommendation #{$1} (#{$2})"
 
         when /ITU-T Recommendation (\w\.\d+)/i
-          "ITU-T Recommendation #{$LAST_MATCH_INFO[1]}"
+          "ITU-T Recommendation #{$1}"
 
         # ITU-R Recommendation 592 MOD
         when /ITU-R Recommendation (\d+)/i
-          "ITU-R Recommendation #{$LAST_MATCH_INFO[1]}"
+          "ITU-R Recommendation #{$1}"
         # ISO 669: 2000 3.1.16
         when /ISO ([\d\-]+:\s?\d{4})/
-          "ISO #{$LAST_MATCH_INFO[1]}".sub(/:\Z/, "")
+          "ISO #{$1}".sub(/:\Z/, "")
         when /ISO ([\d\:\-]+)/
-          "ISO #{$LAST_MATCH_INFO[1]}".sub(/:\Z/, "")
+          "ISO #{$1}".sub(/:\Z/, "")
         when /IEC ([\d\:\-]+)/
-          "IEC #{$LAST_MATCH_INFO[1]}".sub(/:\Z/, "")
+          "IEC #{$1}".sub(/:\Z/, "")
         when /definition (\d\.[\d\.]+) of ([\d\-])/
-          "IEC #{$LAST_MATCH_INFO[2]}".sub(/:\Z/, "")
+          "IEC #{$2}".sub(/:\Z/, "")
         when /définition (\d\.[\d\.]+) de la ([\d\-])/
-          "IEC #{$LAST_MATCH_INFO[2]}".sub(/:\Z/, "")
+          "IEC #{$2}".sub(/:\Z/, "")
 
         when /IEV (\d{2,3}-\d{2,3}-\d{2,3})/, /(\d{2,3}-\d{2,3}-\d{2,3})/
           "IEV"
         when /IEV part\s+(\d+)/, /partie\s+(\d+)\s+de l'IEV/
-          "IEC 60050-#{$LAST_MATCH_INFO[1]}"
+          "IEC 60050-#{$1}"
 
         when /International Telecommunication Union (ITU) Constitution/,
           /Constitution de l’Union internationale des télécommunications (UIT)/
@@ -316,7 +316,7 @@ module IEV
         when /(modified|modifié|modifiée|modifiés|MOD)\s*[–-–]?\s+(.+)\Z/
           {
             "type" => type.to_s,
-            "modification" => $LAST_MATCH_INFO[2],
+            "modification" => $2,
           }
         else
           {

--- a/lib/iev/termbase/source_parser.rb
+++ b/lib/iev/termbase/source_parser.rb
@@ -69,36 +69,7 @@ module IEV
 
         relation_type = extract_source_relationship(raw_ref)
 
-        # définition 3.60 de la 62127-1
-        # definition 3.60 of 62127-1
-        # définition 3.60 de la 62127-1
-        # definition 3.7 of IEC 62127-1 MOD, adapted from 4.2.9 of IEC 61828 and 3.6 of IEC 61102
-        # définition 3.7 de la CEI 62127-1 MOD, adaptées sur la base du 4.2.9 de la CEI 61828 et du 3.6 de la CEI 61102
-        # definition 3.54 of 62127-1 MOD
-        # définition 3.54 de la CEI 62127-1 MOD
-        # IEC 62313:2009, 3.6, modified
-        # IEC 62313:2009, 3.6, modifié
-
-        clean_ref = raw_ref
-          .gsub(/CEI/, "IEC")
-          .gsub(/Guide IEC/, "IEC Guide")
-          .gsub(/Guide ISO\/IEC/, "ISO/IEC Guide")
-          .gsub(/VEI/, "IEV")
-          .gsub(/UIT/, "ITU")
-          .gsub(/IUT-R/, "ITU-R")
-          .gsub(/UTI-R/, "ITU-R")
-          .gsub(/Recomm[ea]ndation ITU-T/, "ITU-T Recommendation")
-          .gsub(/ITU-T (\w.\d{3}):(\d{4})/, 'ITU-T Recommendation \1 (\2)')
-          .gsub(/ITU-R Rec. (\d+)/, 'ITU-R Recommendation \1')
-          .gsub(/[≈≠]\s+/, "")
-          .sub(/ИЗМ\Z/, "MOD")
-          .sub(/definition ([\d\.]+) of ([\d\-\:]+) MOD/, 'IEC \2, \1, modified - ')
-          .sub(/definition ([\d\.]+) of IEC ([\d\-\:]+) MOD/, 'IEC \2, \1, modified - ')
-          .sub(/définition ([\d\.]+) de la ([\d\-\:]+) MOD/, 'IEC \2, \1, modified - ')
-          .sub(/définition ([\d\.]+) de la IEC ([\d\-\:]+) MOD/, 'IEC \2, \1, modified - ')
-          .sub(/(\d{3})\ (\d{2})\ (\d{2})/, '\1-\2-\3') # for 221 04 03
-
-          # .sub(/\A(from|d'après|voir la|see|See|voir|Voir)\s+/, "")
+        clean_ref = normalize_ref_string(raw_ref)
 
         source_ref = extract_source_ref(clean_ref)
           .sub(/, modifi(ed|é)\Z/, "")
@@ -131,6 +102,39 @@ module IEV
         src
       rescue ::RelatonBib::RequestError => e
         warn e.message
+      end
+
+      def normalize_ref_string(str)
+        # définition 3.60 de la 62127-1
+        # definition 3.60 of 62127-1
+        # définition 3.60 de la 62127-1
+        # definition 3.7 of IEC 62127-1 MOD, adapted from 4.2.9 of IEC 61828 and 3.6 of IEC 61102
+        # définition 3.7 de la CEI 62127-1 MOD, adaptées sur la base du 4.2.9 de la CEI 61828 et du 3.6 de la CEI 61102
+        # definition 3.54 of 62127-1 MOD
+        # définition 3.54 de la CEI 62127-1 MOD
+        # IEC 62313:2009, 3.6, modified
+        # IEC 62313:2009, 3.6, modifié
+
+        str
+          .gsub(/CEI/, "IEC")
+          .gsub(/Guide IEC/, "IEC Guide")
+          .gsub(/Guide ISO\/IEC/, "ISO/IEC Guide")
+          .gsub(/VEI/, "IEV")
+          .gsub(/UIT/, "ITU")
+          .gsub(/IUT-R/, "ITU-R")
+          .gsub(/UTI-R/, "ITU-R")
+          .gsub(/Recomm[ea]ndation ITU-T/, "ITU-T Recommendation")
+          .gsub(/ITU-T (\w.\d{3}):(\d{4})/, 'ITU-T Recommendation \1 (\2)')
+          .gsub(/ITU-R Rec. (\d+)/, 'ITU-R Recommendation \1')
+          .gsub(/[≈≠]\s+/, "")
+          .sub(/ИЗМ\Z/, "MOD")
+          .sub(/definition ([\d\.]+) of ([\d\-\:]+) MOD/, 'IEC \2, \1, modified - ')
+          .sub(/definition ([\d\.]+) of IEC ([\d\-\:]+) MOD/, 'IEC \2, \1, modified - ')
+          .sub(/définition ([\d\.]+) de la ([\d\-\:]+) MOD/, 'IEC \2, \1, modified - ')
+          .sub(/définition ([\d\.]+) de la IEC ([\d\-\:]+) MOD/, 'IEC \2, \1, modified - ')
+          .sub(/(\d{3})\ (\d{2})\ (\d{2})/, '\1-\2-\3') # for 221 04 03
+
+          # .sub(/\A(from|d'après|voir la|see|See|voir|Voir)\s+/, "")
       end
 
       def extract_source_ref(str)

--- a/lib/iev/termbase/source_parser.rb
+++ b/lib/iev/termbase/source_parser.rb
@@ -281,11 +281,7 @@ module IEV
 
         # pp results
 
-        if results.first
-          results.first[:clause]
-        else
-          nil
-        end
+        results.dig(0, :clause)
       end
 
       def extract_source_relationship(str)

--- a/lib/iev/termbase/source_parser.rb
+++ b/lib/iev/termbase/source_parser.rb
@@ -89,15 +89,13 @@ module IEV
 
         item = RelatonDb.instance.fetch(source_ref)
 
-        src = {}
-
-        src["ref"] = source_ref
-        src["clause"] = clause if clause
-        src["link"] = item.url if item
-        src["relationship"] = relation_type
-        src["original"] = raw_ref
-
-        src
+        {
+          "ref" => source_ref,
+          "clause" => clause,
+          "link" => item&.url,
+          "relationship" => relation_type,
+          "original" => raw_ref,
+        }.compact
       rescue ::RelatonBib::RequestError => e
         warn e.message
       end

--- a/lib/iev/termbase/source_parser.rb
+++ b/lib/iev/termbase/source_parser.rb
@@ -31,6 +31,10 @@ module IEV
       end
 
       def split_source_field(source)
+        # TODO Calling String#gsub with a single hash argument would be probably
+        # better than calling that method multiple times.  But change is
+        # not necessarily that easy to do.
+
         # IEC 62047-22:2014, 3.1.1, modified – In the definition, ...
         source = source
           .gsub(/;\s?([A-Z][A-Z])/, ';; \1')
@@ -273,6 +277,8 @@ module IEV
           # "ISO/IEC/IEEE 24765:2010,  <i>Systems and software engineering – Vocabulary</i>, 3.234 (2)
           [/, ([\d\.\w]+ \(\d+\))/, "1"],
         ].map do |regex, rule|
+          # TODO Rubocop complains about unused rule -- need to make sure
+          # that no one forgot about something.
           res = []
           # puts "str is '#{str}'"
           # puts "regex is '#{regex.to_s}'"

--- a/lib/iev/termbase/source_parser.rb
+++ b/lib/iev/termbase/source_parser.rb
@@ -108,7 +108,7 @@ module IEV
           .sub(/définition ([\d\.]+) de la IEC ([\d\-\:]+) MOD/, 'IEC \2, \1, modified - ')
           .sub(/(\d{3})\ (\d{2})\ (\d{2})/, '\1-\2-\3') # for 221 04 03
 
-          # .sub(/\A(from|d'après|voir la|see|See|voir|Voir)\s+/, "")
+        # .sub(/\A(from|d'après|voir la|see|See|voir|Voir)\s+/, "")
       end
 
       def extract_source_ref(str)
@@ -198,7 +198,6 @@ module IEV
           debug :sources, "Failed to parse source: '#{str}'"
           str
         end
-
       end
 
       def extract_source_clause(str)
@@ -264,7 +263,7 @@ module IEV
           [/\AISO [\d:]+, (d[ée]finition \d+)/, "1"],
 
           # "ISO/IEC/IEEE 24765:2010,  <i>Systems and software engineering – Vocabulary</i>, 3.234 (2)
-          [/, ([\d\.\w]+ \(\d+\))/, "1"]
+          [/, ([\d\.\w]+ \(\d+\))/, "1"],
         ].map do |regex, rule|
           res = []
           # puts "str is '#{str}'"
@@ -273,7 +272,7 @@ module IEV
             # puts "result is #{result.first}"
             res << {
               index: $~.offset(0)[0],
-              clause: result.first.strip
+              clause: result.first.strip,
             }
           end
           res

--- a/lib/iev/termbase/source_parser.rb
+++ b/lib/iev/termbase/source_parser.rb
@@ -71,7 +71,7 @@ module IEV
 
         clean_ref = normalize_ref_string(raw_ref)
 
-        source_ref = extract_source_ref(clean_ref)
+        source_ref = match_source_ref_string(clean_ref)
           .sub(/, modifi(ed|é)\Z/, "")
           .strip
 
@@ -137,7 +137,7 @@ module IEV
           # .sub(/\A(from|d'après|voir la|see|See|voir|Voir)\s+/, "")
       end
 
-      def extract_source_ref(str)
+      def match_source_ref_string(str)
         case str
         when /SI Brochure/, /Brochure sur le SI/
           # SI Brochure, 9th edition, 2019, 2.3.1

--- a/lib/iev/termbase/source_parser.rb
+++ b/lib/iev/termbase/source_parser.rb
@@ -3,6 +3,8 @@
 # (c) Copyright 2020 Ribose Inc.
 #
 
+# rubocop:todo Style/RedundantRegexpEscape
+
 module IEV
   module Termbase
     # Parses information from the spreadsheet's SOURCE column.
@@ -56,7 +58,7 @@ module IEV
         source = source.gsub(/,\s+ITU/, ";; ITU")
 
         # 705-02-01, 702-02-07
-        source = source.gsub(/(\d{2,3}-\d{2,3}-\d{2,3}),\s*(\d{2,3}-\d{2,3}-\d{2,3})/, '\1;; \2')
+        source = source.gsub(/(\d{2,3}-\d{2,3}-\d{2,3}),\s*(\d{2,3}-\d{2,3}-\d{2,3})/, '\1;; \2') # rubocop:todo Layout/LineLength
 
         source.split(";;").map(&:strip)
       end
@@ -79,6 +81,8 @@ module IEV
       end
 
       def normalize_ref_string(str)
+        # rubocop:todo Layout/LineLength
+
         # définition 3.60 de la 62127-1
         # definition 3.60 of 62127-1
         # définition 3.60 de la 62127-1
@@ -109,6 +113,8 @@ module IEV
           .sub(/(\d{3})\ (\d{2})\ (\d{2})/, '\1-\2-\3') # for 221 04 03
 
         # .sub(/\A(from|d'après|voir la|see|See|voir|Voir)\s+/, "")
+
+        # rubocop:enable Layout/LineLength
       end
 
       def extract_source_ref(str)
@@ -201,6 +207,8 @@ module IEV
       end
 
       def extract_source_clause(str)
+        # rubocop:todo Layout/LineLength
+
         # Strip out the modifications
         str = str.sub(/[,\ ]*modif.+\s[-–].*\Z/, "")
 
@@ -282,6 +290,8 @@ module IEV
         # pp results
 
         results.dig(0, :clause)
+
+        # rubocop:enable Layout/LineLength
       end
 
       def extract_source_relationship(str)
@@ -327,3 +337,5 @@ module IEV
     end
   end
 end
+
+# rubocop:enable Style/RedundantRegexpEscape

--- a/lib/iev/termbase/source_parser.rb
+++ b/lib/iev/termbase/source_parser.rb
@@ -71,9 +71,7 @@ module IEV
 
         clean_ref = normalize_ref_string(raw_ref)
 
-        source_ref = match_source_ref_string(clean_ref)
-          .sub(/, modifi(ed|é)\Z/, "")
-          .strip
+        source_ref = extract_source_ref(clean_ref)
 
         clause = extract_source_clause(clean_ref)
 
@@ -135,6 +133,12 @@ module IEV
           .sub(/(\d{3})\ (\d{2})\ (\d{2})/, '\1-\2-\3') # for 221 04 03
 
           # .sub(/\A(from|d'après|voir la|see|See|voir|Voir)\s+/, "")
+      end
+
+      def extract_source_ref(str)
+        match_source_ref_string(str)
+          .sub(/, modifi(ed|é)\Z/, "")
+          .strip
       end
 
       def match_source_ref_string(str)

--- a/lib/iev/termbase/source_parser.rb
+++ b/lib/iev/termbase/source_parser.rb
@@ -87,12 +87,10 @@ module IEV
 
         # pp h
 
-        item = RelatonDb.instance.fetch(source_ref)
-
         {
           "ref" => source_ref,
           "clause" => clause,
-          "link" => item&.url,
+          "link" => obtain_source_link(source_ref),
           "relationship" => relation_type,
           "original" => raw_ref,
         }.compact
@@ -345,6 +343,11 @@ module IEV
             "type" => type.to_s,
           }
         end
+      end
+
+      # Uses Relaton to obtain link for given source ref.
+      def obtain_source_link(ref)
+        RelatonDb.instance.fetch(ref)&.url
       end
     end
   end


### PR DESCRIPTION
This pull request improves readability and maintainability of `SourceParser` class. It consists of refactoring and other clean-up commits. Values returned by public methods are unchanged in terms of semantics (there is one tiny meaningless change that null source links are removed from output hashes).