### PR TITLE
Delete dead logic from ConceptCollection

### DIFF
--- a/lib/iev/termbase/concept_collection.rb
+++ b/lib/iev/termbase/concept_collection.rb
@@ -24,17 +24,5 @@ module IEV::Termbase
         end
       end
     end
-
-    def to_hash
-      self.inject({}) do |acc, (id, concept)|
-        acc.merge!(id => concept.to_hash)
-      end
-    end
-
-    def to_file(filename)
-      File.open(filename, "w") do |file|
-        file.write(to_hash.to_yaml)
-      end
-    end
   end
 end


### PR DESCRIPTION
These two methods were used to serialize whole concepts collection and write it to one huge YAML, but this is no longer the case.