### PR TITLE
Switch to Ruby 2.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 2.7
 
       - name: Setup
         run: bin/setup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 2.7
 
       - name: Setup
         run: bin/setup
@@ -41,7 +41,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 2.7
 
       - name: Setup
         run: bin/setup
@@ -59,7 +59,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 2.7
 
       - name: Setup
         run: bin/setup
@@ -83,7 +83,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 2.7
 
       - name: Setup
         run: bin/setup

--- a/iev-termbase.gemspec
+++ b/iev-termbase.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = `git ls-files -- {spec}/*`.split("\n")
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
 
+  spec.required_ruby_version = ">= 2.7"
+
   spec.add_runtime_dependency "creek", "~> 2.5"
   spec.add_runtime_dependency "mathml2asciimath", "< 1"
   spec.add_runtime_dependency "relaton", "~> 1.0"


### PR DESCRIPTION
This gem is developed in Ruby 2.7 and meant to be run in Ruby 2.7. Hence, gemspec and GHA workflows are updated accordingly.