### PR TITLE
Updated to work with glossarist version 1.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     iev-termbase (0.1.13)
       creek (~> 2.5)
-      glossarist (~> 0.1.0)
+      glossarist-new (~> 1.0.0)
       mathml2asciimath (< 1)
       relaton (~> 1.0)
       sequel (~> 5.40)
@@ -76,7 +76,7 @@ GEM
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     gb-agencies (0.0.7)
-    glossarist (0.1.2)
+    glossarist-new (1.0.0)
     graphql (1.13.6)
     graphql-client (0.16.0)
       activesupport (>= 3.0)

--- a/iev-termbase.gemspec
+++ b/iev-termbase.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "creek", "~> 2.5"
   spec.add_runtime_dependency "mathml2asciimath", "< 1"
-  spec.add_runtime_dependency "glossarist", "~> 0.1.0"
+  spec.add_runtime_dependency "glossarist-new", "~> 1.0.0"
   spec.add_runtime_dependency "relaton", "~> 1.0"
   spec.add_runtime_dependency "sequel", "~> 5.40"
   spec.add_runtime_dependency "sqlite3", "~> 1.4.2"

--- a/lib/iev/termbase/cli/command.rb
+++ b/lib/iev/termbase/cli/command.rb
@@ -40,6 +40,10 @@ module IEV::Termbase
         summary
       end
 
+      def self.exit_on_failure?
+        true
+      end
+
       # Options must be declared at the bottom because Thor must have commands
       # defined in advance.
 

--- a/lib/iev/termbase/cli/command_helper.rb
+++ b/lib/iev/termbase/cli/command_helper.rb
@@ -13,9 +13,9 @@ module IEV::Termbase
       def save_collection_to_files(collection, output_dir)
         Profiler.measure("writing-yamls") do
           info "Writing concepts to files..."
-          collection.path = File.expand_path("./concepts", output_dir)
-          FileUtils.mkdir_p(collection.path)
-          collection.save_concepts
+          path = File.expand_path("./concepts", output_dir)
+          FileUtils.mkdir_p(path)
+          collection.save_to_files(path)
         end
       end
 
@@ -67,11 +67,13 @@ module IEV::Termbase
 
       def build_collection_from_dataset(dataset)
         Profiler.measure("building-collection") do
-          Glossarist::Collection.new.tap do |concept_collection|
+          Glossarist::ManagedConceptCollection.new.tap do |concept_collection|
             dataset.each do |row|
               term = TermBuilder.build_from(row)
-              concept = concept_collection.fetch_or_initialize(term.id)
-              concept.add_l10n(term)
+              if term
+                concept = concept_collection.fetch_or_initialize(term.id)
+                concept.add_l10n(term)
+              end
             end
           end
         end

--- a/lib/iev/termbase/term_builder.rb
+++ b/lib/iev/termbase/term_builder.rb
@@ -51,12 +51,12 @@ module IEV
           dates: [
             {
               type: :accepted,
-              date: flesh_date(find_value_for("PUBLICATIONDATE"))
+              date: flesh_date(find_value_for("PUBLICATIONDATE")),
             },
             {
               type: :amended,
-              date: flesh_date(find_value_for("PUBLICATIONDATE"))
-            }
+              date: flesh_date(find_value_for("PUBLICATIONDATE")),
+            },
           ],
           review_date: flesh_date(find_value_for("PUBLICATIONDATE")),
           review_decision_date: flesh_date(find_value_for("PUBLICATIONDATE")),


### PR DESCRIPTION
Updated to work with glossarist version 1.0.0

~~**NOTE: Glossarist version 1.0.0 is not yet published and this will not work until it is published.**~~

**NOTE: Published a new gem named `glossarist-new` which is a fork of `glossarist` but has been updated to follow `concept-model`. Using that gem in this PR**