### PR TITLE
Fixing date parse issues

### DIFF
--- a/lib/iev/termbase/term_builder.rb
+++ b/lib/iev/termbase/term_builder.rb
@@ -32,10 +32,12 @@ module IEV
       def flesh_date(incomplete_date)
         return incomplete_date if incomplete_date.nil? || incomplete_date.empty?
 
-        # FIXME: this is a terrible assumption but the IEV export only provides
-        # year and month
-        year, month = incomplete_date.split("-")
-        DateTime.parse("#{year}-#{month || '01'}-01").to_s
+        year, month, day = incomplete_date.split("-")
+
+        month ||= "01"
+        day ||= "01"
+
+        DateTime.parse("#{year}-#{month}-#{day}").to_s
       end
 
       def build_term_object

--- a/spec/iev/termbase/term_builder_spec.rb
+++ b/spec/iev/termbase/term_builder_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe IEV::Termbase::TermBuilder do
+  subject { described_class.new({}) }
+
+  describe "#flesh_date" do
+    context "when date is empty or nil" do
+      it "returns empty date" do
+        expect(subject.flesh_date("")).to eq("")
+        expect(subject.flesh_date(nil)).to be_nil
+      end
+    end
+
+    context "when month and day are missing" do
+      it "defaults them to 01" do
+        expect(subject.flesh_date("2022")).to eq("2022-01-01T00:00:00+00:00")
+      end
+    end
+
+    context "when only day is missing" do
+      it "defaults day to 01" do
+        expect(subject.flesh_date("2022-04")).to eq("2022-04-01T00:00:00+00:00")
+      end
+    end
+
+    context "when full date is given" do
+      it "parses complete date" do
+        expect(subject.flesh_date("2022-04-15")).to eq("2022-04-15T00:00:00+00:00")
+      end
+    end
+  end
+end

--- a/spec/iev/termbase/term_builder_spec.rb
+++ b/spec/iev/termbase/term_builder_spec.rb
@@ -13,19 +13,22 @@ RSpec.describe IEV::Termbase::TermBuilder do
 
     context "when month and day are missing" do
       it "defaults them to 01" do
-        expect(subject.flesh_date("2022")).to eq("2022-01-01T00:00:00+00:00")
+        expect(subject.flesh_date("2022"))
+          .to eq("2022-01-01T00:00:00+00:00")
       end
     end
 
     context "when only day is missing" do
       it "defaults day to 01" do
-        expect(subject.flesh_date("2022-04")).to eq("2022-04-01T00:00:00+00:00")
+        expect(subject.flesh_date("2022-04"))
+          .to eq("2022-04-01T00:00:00+00:00")
       end
     end
 
     context "when full date is given" do
       it "parses complete date" do
-        expect(subject.flesh_date("2022-04-15")).to eq("2022-04-15T00:00:00+00:00")
+        expect(subject.flesh_date("2022-04-15"))
+          .to eq("2022-04-15T00:00:00+00:00")
       end
     end
   end


### PR DESCRIPTION
Date parsing now supports the following formats
- YYYY
- YYYY-MM
- YYYY-MM-DD

closes #27 