### PR TITLE
Parsing source elements to math

### DIFF
--- a/lib/iev/termbase/converter.rb
+++ b/lib/iev/termbase/converter.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module IEV
+  module Termbase
+    module Converter
+      def self.mathml_to_asciimath(input)
+        IEV::Termbase::Converter::MathmlToAsciimath.convert(input)
+      end
+    end
+  end
+end

--- a/lib/iev/termbase/converter/mathml_to_asciimath.rb
+++ b/lib/iev/termbase/converter/mathml_to_asciimath.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+module IEV
+  module Termbase
+    module Converter
+      class MathmlToAsciimath
+        using DataConversions
+
+        def self.convert(input)
+          new.convert(input)
+        end
+
+        def convert(input)
+          mathml_to_asciimath(input)
+        end
+
+        private
+
+        def mathml_to_asciimath(input)
+          # If given string does not include '<' (for elements) nor '&'
+          # (for entities), then it's certain that it doesn't contain
+          # any MathML or HTML formula.
+          return input unless input&.match?(/<|&/)
+
+          unless input.include?("<math>")
+            return html_to_asciimath(input)
+          end
+
+          # puts "GOING TO MATHML MATH"
+          # puts input
+          to_asciimath = Nokogiri::HTML.fragment(input, "UTF-8")
+          # to_asciimath.remove_namespaces!
+
+          to_asciimath.css("math").each do |math_element|
+            asciimath = MathML2AsciiMath.m2a(
+              text_to_asciimath(math_element.to_xml),
+            ).strip
+            # puts"ASCIIMATH!!  #{asciimath}"
+
+            if asciimath.empty?
+              math_element.remove
+            else
+              math_element.replace "stem:[#{asciimath}]"
+            end
+          end
+
+          html_to_asciimath(
+            to_asciimath.children.to_s,
+          )
+        end
+
+        def html_to_asciimath(input)
+          return input if input.nil? || input.empty?
+
+          to_asciimath = Nokogiri::HTML.fragment(input, "UTF-8")
+
+          to_asciimath.css("i").each do |math_element|
+            # puts "HTML MATH!!  #{math_element.to_xml}"
+            # puts "HTML MATH!!  #{math_element.text}"
+            decoded = text_to_asciimath(math_element.text)
+            case decoded.length
+            when 1..12
+              # puts "(#{math_element.text} to => #{decoded})"
+              math_element.replace "stem:[#{decoded}]"
+            when 0
+              math_element.remove
+            else
+              math_element.replace "_#{decoded}_"
+            end
+          end
+
+          to_asciimath.css("sub").each do |math_element|
+            case math_element.text.length
+            when 0
+              math_element.remove
+            else
+              math_element.replace "~#{text_to_asciimath(math_element.text)}~"
+            end
+          end
+
+          to_asciimath.css("sup").each do |math_element|
+            case math_element.text.length
+            when 0
+              math_element.remove
+            else
+              math_element.replace "^#{text_to_asciimath(math_element.text)}^"
+            end
+          end
+
+          to_asciimath.css("ol").each do |element|
+            element.css("li").each do |li|
+              li.replace ". #{li.text}"
+            end
+          end
+
+          to_asciimath.css("ul").each do |element|
+            element.css("li").each do |li|
+              li.replace "* #{li.text}"
+            end
+          end
+
+          # Replace sans-serif font with monospace
+          to_asciimath.css('font[style*="sans-serif"]').each do |x|
+            x.replace "`#{x.text}`"
+          end
+
+          html_entities_to_stem(
+            to_asciimath
+              .children.to_s
+              .gsub(/\]stem:\[/, "")
+              .gsub(/<\/?[uo]l>/, ""),
+          )
+        end
+
+        def text_to_asciimath(text)
+          html_entities_to_asciimath(text.decode_html)
+        end
+
+        def html_entities_to_asciimath(input)
+          input.gsub("&alpha;", "alpha").
+            gsub("&beta;", "beta").
+            gsub("&gamma;", "gamma").
+            gsub("&Gamma;", "Gamma").
+            gsub("&delta;", "delta").
+            gsub("&Delta;", "Delta").
+            gsub("&epsilon;", "epsilon").
+            gsub("&varepsilon;", "varepsilon").
+            gsub("&zeta;", "zeta").
+            gsub("&eta;", "eta").
+            gsub("&theta;", "theta").
+            gsub("&Theta;", "Theta").
+            gsub("&vartheta;", "vartheta").
+            gsub("&iota;", "iota").
+            gsub("&kappa;", "kappa").
+            gsub("&lambda;", "lambda").
+            gsub("&Lambda;", "Lambda").
+            gsub("&mu;", "mu").
+            gsub("&nu;", "nu").
+            gsub("&xi;", "xi").
+            gsub("&Xi;", "Xi").
+            gsub("&pi;", "pi").
+            gsub("&Pi;", "Pi").
+            gsub("&rho;", "rho").
+            gsub("&beta;", "beta").
+            gsub("&sigma;", "sigma").
+            gsub("&Sigma;", "Sigma").
+            gsub("&tau;", "tau").
+            gsub("&upsilon;", "upsilon").
+            gsub("&phi;", "phi").
+            gsub("&Phi;", "Phi").
+            gsub("&varphi;", "varphi").
+            gsub("&chi;", "chi").
+            gsub("&psi;", "psi").
+            gsub("&Psi;", "Psi").
+            gsub("&omega;", "omega")
+        end
+
+        def html_entities_to_stem(input)
+          input.gsub("&alpha;", "stem:[alpha]").
+            gsub("&beta;", "stem:[beta]").
+            gsub("&gamma;", "stem:[gamma]").
+            gsub("&Gamma;", "stem:[Gamma]").
+            gsub("&delta;", "stem:[delta]").
+            gsub("&Delta;", "stem:[Delta]").
+            gsub("&epsilon;", "stem:[epsilon]").
+            gsub("&varepsilon;", "stem:[varepsilon]").
+            gsub("&zeta;", "stem:[zeta]").
+            gsub("&eta;", "stem:[eta]").
+            gsub("&theta;", "stem:[theta]").
+            gsub("&Theta;", "stem:[Theta]").
+            gsub("&vartheta;", "stem:[vartheta]").
+            gsub("&iota;", "stem:[iota]").
+            gsub("&kappa;", "stem:[kappa]").
+            gsub("&lambda;", "stem:[lambda]").
+            gsub("&Lambda;", "stem:[Lambda]").
+            gsub("&mu;", "stem:[mu]").
+            gsub("&nu;", "stem:[nu]").
+            gsub("&xi;", "stem:[xi]").
+            gsub("&Xi;", "stem:[Xi]").
+            gsub("&pi;", "stem:[pi]").
+            gsub("&Pi;", "stem:[Pi]").
+            gsub("&rho;", "stem:[rho]").
+            gsub("&beta;", "stem:[beta]").
+            gsub("&sigma;", "stem:[sigma]").
+            gsub("&Sigma;", "stem:[Sigma]").
+            gsub("&tau;", "stem:[tau]").
+            gsub("&upsilon;", "stem:[upsilon]").
+            gsub("&phi;", "stem:[phi]").
+            gsub("&Phi;", "stem:[Phi]").
+            gsub("&varphi;", "stem:[varphi]").
+            gsub("&chi;", "stem:[chi]").
+            gsub("&psi;", "stem:[psi]").
+            gsub("&Psi;", "stem:[Psi]").
+            gsub("&omega;", "stem:[omega]")
+        end
+      end
+    end
+  end
+end

--- a/lib/iev/termbase/source_parser.rb
+++ b/lib/iev/termbase/source_parser.rb
@@ -18,9 +18,10 @@ module IEV
 
       attr_reader :src_split, :parsed_sources, :raw_str, :src_str
 
-      def initialize(source_str)
+      def initialize(source_str, term_domain)
         @raw_str = source_str.dup.freeze
         @src_str = raw_str.decode_html.sanitize.freeze
+        @term_domain = term_domain
         parse
       end
 
@@ -79,7 +80,9 @@ module IEV
           "clause" => clause,
           "link" => obtain_source_link(source_ref),
           "relationship" => relation_type,
-          "original" => IEV::Termbase::Converter.mathml_to_asciimath(raw_ref),
+          "original" => IEV::Termbase::Converter.mathml_to_asciimath(
+            parse_anchor_tag(raw_ref, @term_domain),
+          ),
         }.compact
       rescue ::RelatonBib::RequestError => e
         warn e.message
@@ -328,7 +331,7 @@ module IEV
           {
             "type" => type.to_s,
             "modification" => IEV::Termbase::Converter.mathml_to_asciimath(
-              $2,
+              parse_anchor_tag($2, @term_domain),
             ).strip,
           }
         else

--- a/lib/iev/termbase/source_parser.rb
+++ b/lib/iev/termbase/source_parser.rb
@@ -13,6 +13,7 @@ module IEV
     #   SourceParser.new(cell_data_string).parsed_sources
     class SourceParser
       include CLI::UI
+      include Utilities
       using DataConversions
 
       attr_reader :src_split, :parsed_sources, :raw_str, :src_str
@@ -78,7 +79,7 @@ module IEV
           "clause" => clause,
           "link" => obtain_source_link(source_ref),
           "relationship" => relation_type,
-          "original" => raw_ref,
+          "original" => IEV::Termbase::Converter.mathml_to_asciimath(raw_ref),
         }.compact
       rescue ::RelatonBib::RequestError => e
         warn e.message
@@ -323,10 +324,12 @@ module IEV
           {
             "type" => type.to_s,
           }
-        when /(modified|modifié|modifiée|modifiés|MOD)\s*[–-–]?\s+(.+)\Z/
+        when /(modified|modifié|modifiée|modifiés|MOD)\s*[–-]?\s+(.+)\Z/
           {
             "type" => type.to_s,
-            "modification" => $2,
+            "modification" => IEV::Termbase::Converter.mathml_to_asciimath(
+              $2,
+            ).strip,
           }
         else
           {

--- a/lib/iev/termbase/term_builder.rb
+++ b/lib/iev/termbase/term_builder.rb
@@ -204,7 +204,7 @@ module IEV
       def extract_definition_value
         if @definition
           IEV::Termbase::Converter.mathml_to_asciimath(
-            replace_newlines(parse_anchor_tag(@definition)),
+            replace_newlines(parse_anchor_tag(@definition, term_domain)),
           ).strip
         end
       end
@@ -212,7 +212,7 @@ module IEV
       def extract_examples
         @examples.map do |str|
           IEV::Termbase::Converter.mathml_to_asciimath(
-            replace_newlines(parse_anchor_tag(str)),
+            replace_newlines(parse_anchor_tag(str, term_domain)),
           ).strip
         end
       end
@@ -220,7 +220,7 @@ module IEV
       def extract_notes
         @notes.map do |str|
           IEV::Termbase::Converter.mathml_to_asciimath(
-            replace_newlines(parse_anchor_tag(str)),
+            replace_newlines(parse_anchor_tag(str, term_domain)),
           ).strip
         end
       end
@@ -251,7 +251,10 @@ module IEV
         source_val = find_value_for("SOURCE")
         return nil if source_val.nil?
 
-        SourceParser.new(source_val).parsed_sources.compact.map do |source|
+        SourceParser.new(source_val, term_domain)
+          .parsed_sources
+          .compact
+          .map do |source|
           source.merge({ "type" => "authoritative" })
         end
       end
@@ -267,7 +270,7 @@ module IEV
 
       def build_expression_designation(raw_term, attribute_data:, status:)
         term = IEV::Termbase::Converter.mathml_to_asciimath(
-          parse_anchor_tag(raw_term),
+          parse_anchor_tag(raw_term, term_domain),
         )
         term_attributes = TermAttrsParser.new(attribute_data.to_s)
 
@@ -291,7 +294,7 @@ module IEV
 
       def build_symbol_designation(raw_term)
         term = IEV::Termbase::Converter.mathml_to_asciimath(
-          parse_anchor_tag(raw_term),
+          parse_anchor_tag(raw_term, term_domain),
         )
 
         {

--- a/lib/iev/termbase/term_builder.rb
+++ b/lib/iev/termbase/term_builder.rb
@@ -250,9 +250,9 @@ module IEV
       def extract_authoritative_source
         source_val = find_value_for("SOURCE")
         return nil if source_val.nil?
+
         SourceParser.new(source_val).parsed_sources.compact.map do |source|
           source.merge({ "type" => "authoritative" })
-
         end
       end
 
@@ -267,7 +267,7 @@ module IEV
 
       def build_expression_designation(raw_term, attribute_data:, status:)
         term = IEV::Termbase::Converter.mathml_to_asciimath(
-          parse_anchor_tag(raw_term)
+          parse_anchor_tag(raw_term),
         )
         term_attributes = TermAttrsParser.new(attribute_data.to_s)
 
@@ -291,7 +291,7 @@ module IEV
 
       def build_symbol_designation(raw_term)
         term = IEV::Termbase::Converter.mathml_to_asciimath(
-          parse_anchor_tag(raw_term)
+          parse_anchor_tag(raw_term),
         )
 
         {

--- a/lib/iev/termbase/term_builder.rb
+++ b/lib/iev/termbase/term_builder.rb
@@ -9,6 +9,7 @@ module IEV
   module Termbase
     class TermBuilder
       include CLI::UI
+      include Utilities
       using DataConversions
 
       def initialize(data)
@@ -86,10 +87,6 @@ module IEV
 
       def term_language
         @term_language ||= find_value_for("LANGUAGE").to_three_char_code
-      end
-
-      def replace_newlines(input)
-        input.gsub('\n', "\n\n").gsub(/<[pbr]+>/, "\n\n").gsub(/\s*\n[\n\s]+/, "\n\n").strip
       end
 
       # Splits unified definition (from the spreadsheet) into separate
@@ -204,194 +201,27 @@ module IEV
         raw_term && build_symbol_designation(raw_term)
       end
 
-      def text_to_asciimath(text)
-        html_entities_to_asciimath(text.decode_html)
-      end
-
-      def html_to_asciimath(input)
-        return input if input.nil? || input.empty?
-
-        to_asciimath = Nokogiri::HTML.fragment(input, "UTF-8")
-
-        to_asciimath.css("i").each do |math_element|
-          # puts "HTML MATH!!  #{math_element.to_xml}"
-          # puts "HTML MATH!!  #{math_element.text}"
-          decoded = text_to_asciimath(math_element.text)
-          case decoded.length
-          when 1..12
-            # puts "(#{math_element.text} to => #{decoded})"
-            math_element.replace "stem:[#{decoded}]"
-          when 0
-            math_element.remove
-          else
-            math_element.replace "_#{decoded}_"
-          end
-        end
-
-        to_asciimath.css("sub").each do |math_element|
-          case math_element.text.length
-          when 0
-            math_element.remove
-          else
-            math_element.replace "~#{text_to_asciimath(math_element.text)}~"
-          end
-        end
-
-        to_asciimath.css("sup").each do |math_element|
-          case math_element.text.length
-          when 0
-            math_element.remove
-          else
-            math_element.replace "^#{text_to_asciimath(math_element.text)}^"
-          end
-        end
-
-        to_asciimath.css("ol").each do |element|
-          element.css("li").each do |li|
-            li.replace ". #{li.text}"
-          end
-        end
-
-        to_asciimath.css("ul").each do |element|
-          element.css("li").each do |li|
-            li.replace "* #{li.text}"
-          end
-        end
-
-        # Replace sans-serif font with monospace
-        to_asciimath.css('font[style*="sans-serif"]').each do |x|
-          x.replace "`#{x.text}`"
-        end
-
-        html_entities_to_stem(
-          to_asciimath.children.to_s.gsub(/\]stem:\[/, "").gsub(/<\/?[uo]l>/, "")
-        )
-      end
-
-      def html_entities_to_asciimath(x)
-        x.gsub("&alpha;", "alpha").
-          gsub("&beta;", "beta").
-          gsub("&gamma;", "gamma").
-          gsub("&Gamma;", "Gamma").
-          gsub("&delta;", "delta").
-          gsub("&Delta;", "Delta").
-          gsub("&epsilon;", "epsilon").
-          gsub("&varepsilon;", "varepsilon").
-          gsub("&zeta;", "zeta").
-          gsub("&eta;", "eta").
-          gsub("&theta;", "theta").
-          gsub("&Theta;", "Theta").
-          gsub("&vartheta;", "vartheta").
-          gsub("&iota;", "iota").
-          gsub("&kappa;", "kappa").
-          gsub("&lambda;", "lambda").
-          gsub("&Lambda;", "Lambda").
-          gsub("&mu;", "mu").
-          gsub("&nu;", "nu").
-          gsub("&xi;", "xi").
-          gsub("&Xi;", "Xi").
-          gsub("&pi;", "pi").
-          gsub("&Pi;", "Pi").
-          gsub("&rho;", "rho").
-          gsub("&beta;", "beta").
-          gsub("&sigma;", "sigma").
-          gsub("&Sigma;", "Sigma").
-          gsub("&tau;", "tau").
-          gsub("&upsilon;", "upsilon").
-          gsub("&phi;", "phi").
-          gsub("&Phi;", "Phi").
-          gsub("&varphi;", "varphi").
-          gsub("&chi;", "chi").
-          gsub("&psi;", "psi").
-          gsub("&Psi;", "Psi").
-          gsub("&omega;", "omega")
-      end
-
-      def html_entities_to_stem(x)
-        x.gsub("&alpha;", "stem:[alpha]").
-          gsub("&beta;", "stem:[beta]").
-          gsub("&gamma;", "stem:[gamma]").
-          gsub("&Gamma;", "stem:[Gamma]").
-          gsub("&delta;", "stem:[delta]").
-          gsub("&Delta;", "stem:[Delta]").
-          gsub("&epsilon;", "stem:[epsilon]").
-          gsub("&varepsilon;", "stem:[varepsilon]").
-          gsub("&zeta;", "stem:[zeta]").
-          gsub("&eta;", "stem:[eta]").
-          gsub("&theta;", "stem:[theta]").
-          gsub("&Theta;", "stem:[Theta]").
-          gsub("&vartheta;", "stem:[vartheta]").
-          gsub("&iota;", "stem:[iota]").
-          gsub("&kappa;", "stem:[kappa]").
-          gsub("&lambda;", "stem:[lambda]").
-          gsub("&Lambda;", "stem:[Lambda]").
-          gsub("&mu;", "stem:[mu]").
-          gsub("&nu;", "stem:[nu]").
-          gsub("&xi;", "stem:[xi]").
-          gsub("&Xi;", "stem:[Xi]").
-          gsub("&pi;", "stem:[pi]").
-          gsub("&Pi;", "stem:[Pi]").
-          gsub("&rho;", "stem:[rho]").
-          gsub("&beta;", "stem:[beta]").
-          gsub("&sigma;", "stem:[sigma]").
-          gsub("&Sigma;", "stem:[Sigma]").
-          gsub("&tau;", "stem:[tau]").
-          gsub("&upsilon;", "stem:[upsilon]").
-          gsub("&phi;", "stem:[phi]").
-          gsub("&Phi;", "stem:[Phi]").
-          gsub("&varphi;", "stem:[varphi]").
-          gsub("&chi;", "stem:[chi]").
-          gsub("&psi;", "stem:[psi]").
-          gsub("&Psi;", "stem:[Psi]").
-          gsub("&omega;", "stem:[omega]")
-      end
-
-      def mathml_to_asciimath(input)
-        # If given string does not include '<' (for elements) nor '&'
-        # (for entities), then it's certain that it doesn't contain
-        # any MathML or HTML formula.
-        return input unless input&.match?(/<|&/)
-
-        unless input.match?(/<math>/)
-          return html_to_asciimath(input)
-        end
-
-        # puts "GOING TO MATHML MATH"
-        # puts input
-        to_asciimath = Nokogiri::HTML.fragment(input, "UTF-8")
-        # to_asciimath.remove_namespaces!
-
-        to_asciimath.css("math").each do |math_element|
-          asciimath = MathML2AsciiMath.m2a(text_to_asciimath(math_element.to_xml)).strip
-          # puts"ASCIIMATH!!  #{asciimath}"
-
-          if asciimath.empty?
-            math_element.remove
-          else
-            math_element.replace "stem:[#{asciimath}]"
-          end
-        end
-
-        html_to_asciimath(
-          to_asciimath.children.to_s
-        )
-      end
-
       def extract_definition_value
         if @definition
-          mathml_to_asciimath(replace_newlines(parse_anchor_tag(@definition))).strip
+          IEV::Termbase::Converter.mathml_to_asciimath(
+            replace_newlines(parse_anchor_tag(@definition)),
+          ).strip
         end
       end
 
       def extract_examples
         @examples.map do |str|
-          mathml_to_asciimath(replace_newlines(parse_anchor_tag(str))).strip
+          IEV::Termbase::Converter.mathml_to_asciimath(
+            replace_newlines(parse_anchor_tag(str)),
+          ).strip
         end
       end
 
       def extract_notes
         @notes.map do |str|
-          mathml_to_asciimath(replace_newlines(parse_anchor_tag(str))).strip
+          IEV::Termbase::Converter.mathml_to_asciimath(
+            replace_newlines(parse_anchor_tag(str)),
+          ).strip
         end
       end
 
@@ -422,6 +252,7 @@ module IEV
         return nil if source_val.nil?
         SourceParser.new(source_val).parsed_sources.compact.map do |source|
           source.merge({ "type" => "authoritative" })
+
         end
       end
 
@@ -432,31 +263,12 @@ module IEV
         SupersessionParser.new(replaces_val).supersessions
       end
 
-      SIMG_PATH_REGEX = "<simg .*\\/\\$file\\/([\\d\\-\\w\.]+)>"
-      FIGURE_ONE_REGEX = "<p><b>\\s*Figure\\s+(\\d)\\s+[–-]\\s+(.+)\\s*<\\/b>(<\\/p>)?"
-      FIGURE_TWO_REGEX = "#{FIGURE_ONE_REGEX}\\s*#{FIGURE_ONE_REGEX}"
-      def parse_anchor_tag(text)
-        if text
-          # Convert IEV term references
-          # Convert href links
-          # Need to take care of this pattern: `inverse de la <a href="IEV103-06-01">période<a>`
-          text.
-            gsub(/<a href="?(IEV)\s*(\d\d\d-\d\d-\d\d)"?>(.*?)<\/?a>/, '{{\3, \1:\2}}').
-            gsub(/<a href="?\s*(\d\d\d-\d\d-\d\d)"?>(.*?)<\/?a>/, '{{\3, IEV:\2}}').
-            gsub(/<a href="(.*?)">(.*?)<\/a>/, '\1[\2]').
-            gsub(Regexp.new([SIMG_PATH_REGEX, "\\s*", FIGURE_TWO_REGEX].join("")), "image::/assets/images/parts/#{term_domain}/\\1[Figure \\2 - \\3; \\6]").
-            gsub(Regexp.new([SIMG_PATH_REGEX, "\\s*", FIGURE_ONE_REGEX].join("")), "image::/assets/images/parts/#{term_domain}/\\1[Figure \\2 - \\3]").
-            gsub(/<img\s+(.+?)\s*>/, "image::/assets/images/parts/#{term_domain}/\\1[]").
-            gsub(/<br>/, "\n").
-            gsub(/<b>(.*?)<\/b>/, "*\\1*")
-
-        end
-      end
-
       private
 
       def build_expression_designation(raw_term, attribute_data:, status:)
-        term = mathml_to_asciimath(parse_anchor_tag(raw_term))
+        term = IEV::Termbase::Converter.mathml_to_asciimath(
+          parse_anchor_tag(raw_term)
+        )
         term_attributes = TermAttrsParser.new(attribute_data.to_s)
 
         statuses = {
@@ -478,7 +290,9 @@ module IEV
       end
 
       def build_symbol_designation(raw_term)
-        term = mathml_to_asciimath(parse_anchor_tag(raw_term))
+        term = IEV::Termbase::Converter.mathml_to_asciimath(
+          parse_anchor_tag(raw_term)
+        )
 
         {
           "type" => "symbol",

--- a/lib/iev/termbase/utilities.rb
+++ b/lib/iev/termbase/utilities.rb
@@ -3,31 +3,51 @@
 module IEV
   module Termbase
     module Utilities
-
       SIMG_PATH_REGEX = "<simg .*\\/\\$file\\/([\\d\\-\\w\.]+)>"
-      FIGURE_ONE_REGEX = "<p><b>\\s*Figure\\s+(\\d)\\s+[–-]\\s+(.+)\\s*<\\/b>(<\\/p>)?"
+      FIGURE_ONE_REGEX =
+        "<p><b>\\s*Figure\\s+(\\d)\\s+[–-]\\s+(.+)\\s*<\\/b>(<\\/p>)?"
       FIGURE_TWO_REGEX = "#{FIGURE_ONE_REGEX}\\s*#{FIGURE_ONE_REGEX}"
+      IMAGE_PATH_PREFIX = "image::/assets/images/parts"
 
       def parse_anchor_tag(text)
         if text
           # Convert IEV term references
           # Convert href links
-          # Need to take care of this pattern: `inverse de la <a href="IEV103-06-01">période<a>`
-          text.
-            gsub(/<a href="?(IEV)\s*(\d\d\d-\d\d-\d\d)"?>(.*?)<\/?a>/, '{{\3, \1:\2}}').
-            gsub(/<a href="?\s*(\d\d\d-\d\d-\d\d)"?>(.*?)<\/?a>/, '{{\3, IEV:\2}}').
-            gsub(/<a href="(.*?)">(.*?)<\/a>/, '\1[\2]').
-            gsub(Regexp.new([SIMG_PATH_REGEX, "\\s*", FIGURE_TWO_REGEX].join("")), "image::/assets/images/parts/#{term_domain}/\\1[Figure \\2 - \\3; \\6]").
-            gsub(Regexp.new([SIMG_PATH_REGEX, "\\s*", FIGURE_ONE_REGEX].join("")), "image::/assets/images/parts/#{term_domain}/\\1[Figure \\2 - \\3]").
-            gsub(/<img\s+(.+?)\s*>/, "image::/assets/images/parts/#{term_domain}/\\1[]").
-            gsub(/<br>/, "\n").
-            gsub(/<b>(.*?)<\/b>/, "*\\1*")
-
+          # Need to take care of this pattern:
+          #  `inverse de la <a href="IEV103-06-01">période<a>`
+          text.gsub(
+            /<a href="?(IEV)\s*(\d\d\d-\d\d-\d\d)"?>(.*?)<\/?a>/,
+            '{{\3, \1:\2}}',
+          ).gsub(
+            /<a href="?\s*(\d\d\d-\d\d-\d\d)"?>(.*?)<\/?a>/,
+            '{{\3, IEV:\2}}',
+          ).gsub(
+            /<a href="(.*?)">(.*?)<\/a>/,
+            '\1[\2]',
+          ).gsub(
+            Regexp.new([SIMG_PATH_REGEX, "\\s*", FIGURE_TWO_REGEX].join),
+            "#{IMAGE_PATH_PREFIX}/#{term_domain}/\\1[Figure \\2 - \\3; \\6]",
+          ).gsub(
+            Regexp.new([SIMG_PATH_REGEX, "\\s*", FIGURE_ONE_REGEX].join),
+            "#{IMAGE_PATH_PREFIX}/#{term_domain}/\\1[Figure \\2 - \\3]",
+          ).gsub(
+            /<img\s+(.+?)\s*>/,
+            "#{IMAGE_PATH_PREFIX}/#{term_domain}/\\1[]",
+          ).gsub(
+            /<br>/,
+            "\n",
+          ).gsub(
+            /<b>(.*?)<\/b>/,
+            "*\\1*",
+          )
         end
       end
 
       def replace_newlines(input)
-        input.gsub('\n', "\n\n").gsub(/<[pbr]+>/, "\n\n").gsub(/\s*\n[\n\s]+/, "\n\n").strip
+        input.gsub('\n', "\n\n")
+          .gsub(/<[pbr]+>/, "\n\n")
+          .gsub(/\s*\n[\n\s]+/, "\n\n")
+          .strip
       end
     end
   end

--- a/lib/iev/termbase/utilities.rb
+++ b/lib/iev/termbase/utilities.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module IEV
+  module Termbase
+    module Utilities
+
+      SIMG_PATH_REGEX = "<simg .*\\/\\$file\\/([\\d\\-\\w\.]+)>"
+      FIGURE_ONE_REGEX = "<p><b>\\s*Figure\\s+(\\d)\\s+[–-]\\s+(.+)\\s*<\\/b>(<\\/p>)?"
+      FIGURE_TWO_REGEX = "#{FIGURE_ONE_REGEX}\\s*#{FIGURE_ONE_REGEX}"
+
+      def parse_anchor_tag(text)
+        if text
+          # Convert IEV term references
+          # Convert href links
+          # Need to take care of this pattern: `inverse de la <a href="IEV103-06-01">période<a>`
+          text.
+            gsub(/<a href="?(IEV)\s*(\d\d\d-\d\d-\d\d)"?>(.*?)<\/?a>/, '{{\3, \1:\2}}').
+            gsub(/<a href="?\s*(\d\d\d-\d\d-\d\d)"?>(.*?)<\/?a>/, '{{\3, IEV:\2}}').
+            gsub(/<a href="(.*?)">(.*?)<\/a>/, '\1[\2]').
+            gsub(Regexp.new([SIMG_PATH_REGEX, "\\s*", FIGURE_TWO_REGEX].join("")), "image::/assets/images/parts/#{term_domain}/\\1[Figure \\2 - \\3; \\6]").
+            gsub(Regexp.new([SIMG_PATH_REGEX, "\\s*", FIGURE_ONE_REGEX].join("")), "image::/assets/images/parts/#{term_domain}/\\1[Figure \\2 - \\3]").
+            gsub(/<img\s+(.+?)\s*>/, "image::/assets/images/parts/#{term_domain}/\\1[]").
+            gsub(/<br>/, "\n").
+            gsub(/<b>(.*?)<\/b>/, "*\\1*")
+
+        end
+      end
+
+      def replace_newlines(input)
+        input.gsub('\n', "\n\n").gsub(/<[pbr]+>/, "\n\n").gsub(/\s*\n[\n\s]+/, "\n\n").strip
+      end
+    end
+  end
+end

--- a/lib/iev/termbase/utilities.rb
+++ b/lib/iev/termbase/utilities.rb
@@ -9,20 +9,26 @@ module IEV
       FIGURE_TWO_REGEX = "#{FIGURE_ONE_REGEX}\\s*#{FIGURE_ONE_REGEX}"
       IMAGE_PATH_PREFIX = "image::/assets/images/parts"
 
-      def parse_anchor_tag(text)
+      def parse_anchor_tag(text, term_domain)
         if text
           # Convert IEV term references
           # Convert href links
           # Need to take care of this pattern:
           #  `inverse de la <a href="IEV103-06-01">période<a>`
           text.gsub(
-            /<a href="?(IEV)\s*(\d\d\d-\d\d-\d\d)"?>(.*?)<\/?a>/,
+            /<a href="?(IEV)\s*(\d\d\d-\d\d-\d\d\d?)"?>(.*?)<\/?a>/,
             '{{\3, \1:\2}}',
           ).gsub(
-            /<a href="?\s*(\d\d\d-\d\d-\d\d)"?>(.*?)<\/?a>/,
+            /<a href="?\s*(\d\d\d-\d\d-\d\d\d?)"?>(.*?)<\/?a>/,
             '{{\3, IEV:\2}}',
           ).gsub(
-            /<a href="(.*?)">(.*?)<\/a>/,
+            # To handle <a> tags without ending tag like
+            #  `Voir <a href=IEV103-05-21>IEV 103-05-21`
+            #  for concept '702-03-11' in `fr`
+            /<a href="?(IEV)?\s*(\d\d\d-\d\d-\d\d\d?)"?>(.*?)$/,
+            '{{\3, IEV:\2}}',
+          ).gsub(
+            /<a href="?(.*?)"?>(.*?)<\/a>/,
             '\1[\2]',
           ).gsub(
             Regexp.new([SIMG_PATH_REGEX, "\\s*", FIGURE_TWO_REGEX].join),

--- a/spec/iev/termbase/source_parser_spec.rb
+++ b/spec/iev/termbase/source_parser_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe IEV::Termbase::SourceParser do
   subject do
     example = RSpec.current_example
     attributes_str = example.metadata[:string] || example.description
-    described_class.new(attributes_str)
+    described_class.new(attributes_str, "IEV")
   end
 
   around do |example|

--- a/spec/iev/termbase/source_parser_spec.rb
+++ b/spec/iev/termbase/source_parser_spec.rb
@@ -57,4 +57,21 @@ RSpec.describe IEV::Termbase::SourceParser do
       .and contain_exactly("CEI 62303:2008, 3.1, modifiée",
         "CEI 62302:2007, 3.2", "AIEA 4")
   end
+
+  example "IEC 62302:2007, 3.2, modified – math element \"<i>L</i>\"" do
+    expected_parsed_sources = {
+      "ref" => "IEC 62302:2007",
+      "clause" => "3.2",
+      "link" => "https://webstore.iec.ch/publication/6790",
+      "relationship" => {
+        "type" => "modified",
+        "modification" => "math element \"stem:[L]\"",
+      },
+      "original" => "IEC 62302:2007, 3.2, modified – math element \"stem:[L]\"",
+    }
+
+    expect(subject.parsed_sources)
+      .to be_an(Array)
+      .and contain_exactly(expected_parsed_sources)
+  end
 end

--- a/spec/iev/termbase/utilities_spec.rb
+++ b/spec/iev/termbase/utilities_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+class TestUtilites
+  include IEV::Termbase::Utilities
+end
+
+RSpec.describe IEV::Termbase::Utilities do
+  subject { TestUtilites.new }
+
+  describe "#parse_anchor_tag" do
+    context "when end tag is present" do
+      it "converts the a tag with quotes to asciidoc format" do
+        text = "See <a href=\"IEV121-02-02\">121-02-02</a>"
+
+        expect(subject.parse_anchor_tag(text, "IEV"))
+          .to eq("See {{121-02-02, IEV:121-02-02}}")
+      end
+
+      it "converts the a tag with quotes to asciidoc format" do
+        text = "See <a href=IEV121-02-03>121-02-03</a>"
+
+        expect(subject.parse_anchor_tag(text, "IEV"))
+          .to eq("See {{121-02-03, IEV:121-02-03}}")
+      end
+    end
+
+    context "when end tag is not present" do
+      it "converts the a tag with quotes to asciidoc format" do
+        text = "See <a href=\"IEV121-02-02\">No end tag"
+
+        expect(subject.parse_anchor_tag(text, "IEV"))
+          .to eq("See {{No end tag, IEV:121-02-02}}")
+      end
+
+      it "converts the a tag with quotes to asciidoc format" do
+        text = "See <a href=IEV121-02-03>No end tag"
+
+        expect(subject.parse_anchor_tag(text, "IEV"))
+          .to eq("See {{No end tag, IEV:121-02-03}}")
+      end
+    end
+  end
+
+  describe "#replace_newlines" do
+    it "should replace <br> tag with newlines" do
+      expect(subject.replace_newlines("Hello<br>world"))
+        .to eq("Hello\n\nworld")
+    end
+
+    it "should replace <p> tag with newlines" do
+      expect(subject.replace_newlines("Hello<p>world"))
+        .to eq("Hello\n\nworld")
+    end
+
+    it "should replace \\n tag with newlines" do
+      expect(subject.replace_newlines("Hello\\nworld"))
+        .to eq("Hello\n\nworld")
+    end
+
+    it "should replace multiple \\n tag with newlines" do
+      expect(subject.replace_newlines("Hello\\n\\n\\n\\n\\n\\nworld"))
+        .to eq("Hello\n\nworld")
+    end
+  end
+end


### PR DESCRIPTION
- Parsing sources to math

### Old

```yaml
en:
  sources:
  - type: authoritative
    status: modified
    origin:
      clause: Appendix 1
      original: SI Brochure, 9th edition, 2019, Appendix 1, modified – The definition
        in the SI Brochure has been revised to comply with the IEV rules. The synonym
        "Loschmidt number" and the symbol "<i>L</i>" have been added to Note 2 to
        entry.
    modification: The definition in the SI Brochure has been revised to comply with
      the IEV rules. The synonym "Loschmidt number" and the symbol "<i>L</i>" have
      been added to Note 2 to entry.
```

### New

```yaml
en:
  sources:
  - type: authoritative
    status: modified
    origin:
      clause: Appendix 1
      original: SI Brochure, 9th edition, 2019, Appendix 1, modified – The definition
        in the SI Brochure has been revised to comply with the IEV rules. The synonym
        "Loschmidt number" and the symbol "stem:[L]" have been added to Note 2 to
        entry.
    modification: The definition in the SI Brochure has been revised to comply with
      the IEV rules. The synonym "Loschmidt number" and the symbol "stem:[L]" have
      been added to Note 2 to entry.
```

closes #122 